### PR TITLE
Add more information about previous insurer and if we can switch or not

### DIFF
--- a/src/features/insurance/index.ts
+++ b/src/features/insurance/index.ts
@@ -1,6 +1,27 @@
 import { getInsurance, getUser } from '../../api'
 import { ForwardHeaders } from '../../context'
 import { Insurance } from '../../typings/generated-graphql-types'
+import { PreviousInsurer } from './../../typings/generated-graphql-types'
+
+const switchableInsuranceProviders = [
+  'ICA',
+  'FOLKSAM',
+  'TRYGG_HANSA',
+  'TRE_KRONOR',
+]
+
+const previousInsurerMap = new Map<String, String>([
+  ['LANSFORSAKRINGAR', 'Länsförsäkringar'],
+  ['IF', 'If'],
+  ['FOLKSAM', 'Folksam'],
+  ['TRYGG_HANSA', 'Trygg-Hansa'],
+  ['MODERNA', 'Moderna Försäkringar'],
+  ['ICA', 'ICA Försäkring'],
+  ['GJENSIDIGE', 'Gjensidige'],
+  ['VARDIA', 'Vardia'],
+  ['TRE_KRONOR', 'Tre kronor'],
+  ['OTHER', ''],
+])
 
 const loadInsurance = async (
   token: string,
@@ -10,6 +31,18 @@ const loadInsurance = async (
     getInsurance(token, headers),
     getUser(token, headers),
   ])
+
+  const previousInsurer = insuranceResponse.insuredAtOtherCompany
+    ? ({
+        identifier: insuranceResponse.currentInsurerName,
+        displayName: previousInsurerMap.get(
+          insuranceResponse.currentInsurerName,
+        ),
+        switchable: switchableInsuranceProviders.includes(
+          insuranceResponse.currentInsurerName,
+        ),
+      } as PreviousInsurer)
+    : undefined
 
   return {
     insuredAtOtherCompany: insuranceResponse.insuredAtOtherCompany,
@@ -34,6 +67,7 @@ const loadInsurance = async (
     monthlyCost: insuranceResponse.currentTotalPrice,
     safetyIncreasers: user.safetyIncreasers,
     renewal: insuranceResponse.renewal,
+    previousInsurer,
   }
 }
 

--- a/src/features/insurance/index.ts
+++ b/src/features/insurance/index.ts
@@ -34,7 +34,7 @@ const loadInsurance = async (
 
   const previousInsurer = insuranceResponse.insuredAtOtherCompany
     ? ({
-        identifier: insuranceResponse.currentInsurerName,
+        id: insuranceResponse.currentInsurerName,
         displayName: previousInsurerMap.get(
           insuranceResponse.currentInsurerName,
         ),

--- a/src/schema.graphqls
+++ b/src/schema.graphqls
@@ -383,7 +383,7 @@ type Insurance {
 
 type PreviousInsurer {
   displayName: String
-  identifier: String!
+  id: ID!
   switchable: Boolean!
 }
 

--- a/src/schema.graphqls
+++ b/src/schema.graphqls
@@ -358,10 +358,14 @@ type Insurance {
   status: InsuranceStatus!
   type: InsuranceType
   activeFrom: LocalDate
-  insuredAtOtherCompany: Boolean
+  insuredAtOtherCompany: Boolean @deprecated(
+    reason: "Use previousInsurer instead"
+  )
   presaleInformationUrl: String
   policyUrl: String
-  currentInsurerName: String
+  currentInsurerName: String @deprecated(
+    reason: "Use previousInsurer instead"
+  )
   livingSpace: Int
   perilCategories: [PerilCategory] @deprecated(
     reason: "Use arrangedPerilCategories instead"
@@ -374,6 +378,13 @@ type Insurance {
   )
   arrangedPerilCategories: ArrangedPerilCategories!
   renewal: Renewal
+  previousInsurer: PreviousInsurer
+}
+
+type PreviousInsurer {
+  displayName: String
+  identifier: String!
+  switchable: Boolean!
 }
 
 type Renewal {

--- a/src/typings/generated-graphql-types.ts
+++ b/src/typings/generated-graphql-types.ts
@@ -128,8 +128,8 @@ export interface Renewal {
 }
 
 export interface PreviousInsurer {
-  displayName: string;
-  identifier: string;
+  displayName?: string;
+  id: string;
   switchable: boolean;
 }
 
@@ -986,15 +986,15 @@ export interface RenewalToDateResolver<TParent = Renewal, TResult = LocalDate> {
 
 export interface PreviousInsurerTypeResolver<TParent = PreviousInsurer> {
   displayName?: PreviousInsurerToDisplayNameResolver<TParent>;
-  identifier?: PreviousInsurerToIdentifierResolver<TParent>;
+  id?: PreviousInsurerToIdResolver<TParent>;
   switchable?: PreviousInsurerToSwitchableResolver<TParent>;
 }
 
-export interface PreviousInsurerToDisplayNameResolver<TParent = PreviousInsurer, TResult = string> {
+export interface PreviousInsurerToDisplayNameResolver<TParent = PreviousInsurer, TResult = string | null> {
   (parent: TParent, args: {}, context: Context, info: GraphQLResolveInfo): TResult | Promise<TResult>;
 }
 
-export interface PreviousInsurerToIdentifierResolver<TParent = PreviousInsurer, TResult = string> {
+export interface PreviousInsurerToIdResolver<TParent = PreviousInsurer, TResult = string> {
   (parent: TParent, args: {}, context: Context, info: GraphQLResolveInfo): TResult | Promise<TResult>;
 }
 

--- a/src/typings/generated-graphql-types.ts
+++ b/src/typings/generated-graphql-types.ts
@@ -36,9 +36,19 @@ export interface Insurance {
   status: InsuranceStatus;
   type?: InsuranceType;
   activeFrom?: LocalDate;
+  
+  /**
+   * 
+   * @deprecated Use previousInsurer instead
+   */
   insuredAtOtherCompany?: boolean;
   presaleInformationUrl?: string;
   policyUrl?: string;
+  
+  /**
+   * 
+   * @deprecated Use previousInsurer instead
+   */
   currentInsurerName?: string;
   livingSpace?: number;
   
@@ -61,6 +71,7 @@ export interface Insurance {
   safetyIncreasers?: Array<string>;
   arrangedPerilCategories: ArrangedPerilCategories;
   renewal?: Renewal;
+  previousInsurer?: PreviousInsurer;
 }
 
 export interface InsuranceCost {
@@ -114,6 +125,12 @@ export interface ArrangedPerilCategories {
 export interface Renewal {
   certificateUrl: string;
   date: LocalDate;
+}
+
+export interface PreviousInsurer {
+  displayName: string;
+  identifier: string;
+  switchable: boolean;
 }
 
 export interface Cashback {
@@ -636,6 +653,7 @@ export interface Resolver {
   Peril?: PerilTypeResolver;
   ArrangedPerilCategories?: ArrangedPerilCategoriesTypeResolver;
   Renewal?: RenewalTypeResolver;
+  PreviousInsurer?: PreviousInsurerTypeResolver;
   Cashback?: CashbackTypeResolver;
   SignStatus?: SignStatusTypeResolver;
   CollectStatus?: CollectStatusTypeResolver;
@@ -779,6 +797,7 @@ export interface InsuranceTypeResolver<TParent = Insurance> {
   safetyIncreasers?: InsuranceToSafetyIncreasersResolver<TParent>;
   arrangedPerilCategories?: InsuranceToArrangedPerilCategoriesResolver<TParent>;
   renewal?: InsuranceToRenewalResolver<TParent>;
+  previousInsurer?: InsuranceToPreviousInsurerResolver<TParent>;
 }
 
 export interface InsuranceToAddressResolver<TParent = Insurance, TResult = string | null> {
@@ -850,6 +869,10 @@ export interface InsuranceToArrangedPerilCategoriesResolver<TParent = Insurance,
 }
 
 export interface InsuranceToRenewalResolver<TParent = Insurance, TResult = Renewal | null> {
+  (parent: TParent, args: {}, context: Context, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+}
+
+export interface InsuranceToPreviousInsurerResolver<TParent = Insurance, TResult = PreviousInsurer | null> {
   (parent: TParent, args: {}, context: Context, info: GraphQLResolveInfo): TResult | Promise<TResult>;
 }
 
@@ -958,6 +981,24 @@ export interface RenewalToCertificateUrlResolver<TParent = Renewal, TResult = st
 }
 
 export interface RenewalToDateResolver<TParent = Renewal, TResult = LocalDate> {
+  (parent: TParent, args: {}, context: Context, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+}
+
+export interface PreviousInsurerTypeResolver<TParent = PreviousInsurer> {
+  displayName?: PreviousInsurerToDisplayNameResolver<TParent>;
+  identifier?: PreviousInsurerToIdentifierResolver<TParent>;
+  switchable?: PreviousInsurerToSwitchableResolver<TParent>;
+}
+
+export interface PreviousInsurerToDisplayNameResolver<TParent = PreviousInsurer, TResult = string> {
+  (parent: TParent, args: {}, context: Context, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+}
+
+export interface PreviousInsurerToIdentifierResolver<TParent = PreviousInsurer, TResult = string> {
+  (parent: TParent, args: {}, context: Context, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+}
+
+export interface PreviousInsurerToSwitchableResolver<TParent = PreviousInsurer, TResult = boolean> {
   (parent: TParent, args: {}, context: Context, info: GraphQLResolveInfo): TResult | Promise<TResult>;
 }
 


### PR DESCRIPTION
The logic for identifying which providers we can switch from was in the app repo before, and it doesn't make too much sense to have it in two separate code bases going forward (android & ios), so moving the logic to here instead.

poke @hedvigoscar @FredrikAreschoug you might like this