### PR TITLE
attach the auth token to the body

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -770,7 +770,7 @@ const norwegianAuthMember = (
       mergeOptions: {
         headers: (headers as any) as RequestInit['headers'],
         method: 'POST',
-        body: JSON.stringify(body),
+        body: JSON.stringify({...body, token}),
       },
       token,
     }).then((res) => res.json())
@@ -784,7 +784,7 @@ const danishAuthMember = (
       mergeOptions: {
         headers: (headers as any) as RequestInit['headers'],
         method: 'POST',
-        body: JSON.stringify(body),
+        body: JSON.stringify({...body, token}),
       },
       token,
     }).then((res) => res.json())


### PR DESCRIPTION
## What?
Authorization header is implicitly stripped in api gateway. Send in body instead.

## Why?
Current code doesn't work 🙃 
