### PR TITLE
Forward locale to angel data

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -39,6 +39,9 @@ const handleError = (error: GraphQLError): void => {
   )
 }
 
+logger.info('Starting Giraffe 🦒')
+logger.info('Making schema')
+
 makeSchema()
   .then(({ schema, graphCMSSchema }) => {
     logger.info('Schema initialized')

--- a/src/resolvers/angelStory.ts
+++ b/src/resolvers/angelStory.ts
@@ -7,10 +7,14 @@ const logger = factory.getLogger('angelStory')
 
 export const angelStory: QueryToAngelStoryResolver = async (
   _parent,
-  { name },
+  { name, locale },
 ) => {
   try {
-    const story = await fetch(`${config.ANGEL_URL}angel-data?name=${name}`)
+    const story = await fetch(
+      `${config.ANGEL_URL}angel-data?name=${encodeURIComponent(
+        name,
+      )}&locale=${encodeURIComponent(locale || '')}`,
+    )
     return {
       content: await story.text(),
     }

--- a/src/schema.graphqls
+++ b/src/schema.graphqls
@@ -12,7 +12,7 @@ type Query {
   avatars: [Avatar]
   chatActions: [ChatAction]
   geo: Geo!
-  angelStory(name: String!): AngelStory
+  angelStory(name: String!, locale: String): AngelStory
 }
 
 type Mutation {

--- a/src/typings/generated-graphql-types.ts
+++ b/src/typings/generated-graphql-types.ts
@@ -1113,6 +1113,7 @@ export interface QueryToGeoResolver<TParent = undefined, TResult = Geo> {
 
 export interface QueryToAngelStoryArgs {
   name: string;
+  locale?: string;
 }
 export interface QueryToAngelStoryResolver<TParent = undefined, TResult = AngelStory | null> {
   (parent: TParent, args: QueryToAngelStoryArgs, context: Context, info: GraphQLResolveInfo): TResult | Promise<TResult>;


### PR DESCRIPTION
What: Allow the option of forwarding the locale string to embark when fetching raw angel data

Why: So we can pick up translations everywhere we fetch angel data