### PR TITLE
Revert the schema stitching madness

### DIFF
--- a/src/resolvers/cross-schema/index.ts
+++ b/src/resolvers/cross-schema/index.ts
@@ -10,6 +10,7 @@ export const crossSchemaExtensions = `
   extend type Contract {
     perils(locale: Locale!): [PerilV2!]!
     insurableLimits(locale: Locale!): [InsurableLimit!]!
+    termsAndConditions(locale: Locale!): InsuranceTerm!
     insuranceTerms(locale: Locale!): [InsuranceTerm!]!
   }
 
@@ -267,6 +268,27 @@ export const getCrossSchemaResolvers = (
             schema: contentSchema,
             operation: 'query',
             fieldName: 'insurableLimits',
+            args: {
+              contractType: contract.typeOfContract,
+              locale: args.locale,
+            },
+            context,
+            info,
+          })
+        },
+      },
+      termsAndConditions: {
+        fragment: `fragment CompleteQuoteCrossSchemaFragment on Contract { typeOfContract }`,
+        resolve: (
+          contract: Contract,
+          args: TermsAndConditionsArgs,
+          context,
+          info,
+        ) => {
+          return info.mergeInfo.delegateToSchema({
+            schema: contentSchema,
+            operation: 'query',
+            fieldName: 'termsAndConditions',
             args: {
               contractType: contract.typeOfContract,
               locale: args.locale,


### PR DESCRIPTION
Revert "Remove `termsAndConditions` from `Contract` in cross-schema resolver. (#1065)"

This reverts commit 2351a11c0cbee052168173d54ca70156e41b4c32.

## Why

- With the fix in HedvigInsurance/product-pricing#691 we should revert back to using the cross-schema resolution for the old (now deprecated) `termsAndConditions` field on `Contract`. This will keep backwards compatibility.
- This will obviously need to be deployed in synchronicity with the change in product-pricing.