### PR TITLE
Create a mutation for creating a 'self change'-related quote

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -63,6 +63,7 @@ interface UserDto {
   selectedCashback: string
   selectedCashbackImageUrl: string
   ssn: string
+  birthDate: string
 }
 
 interface SignDto {
@@ -169,19 +170,20 @@ interface PushTokenDto {
 }
 
 interface CreateQuoteDto {
+  memberId: String
   firstName: string
   lastName: string
-  email?: string
-  ssn?: string
+  ssn: string
+  birthDate: string
   startDate: string
-  incompleteApartmentQuoteData?: {
+  swedishApartmentData?: {
     street: string
     zipCode: string
     householdSize: number
     livingSpace: number
     subType: string
   }
-  incompleteHouseQuoteData?: {
+  swedishHouseData?: {
     street: string
     zipCode: string
     householdSize: number
@@ -196,7 +198,7 @@ interface CreateQuoteDto {
       hasWaterConnected: boolean
     }[]
   }
-  norwegianHomeContents?: {
+  norwegianHomeContentsData?: {
     street: string
     zipCode: string
     coInsured: number
@@ -204,11 +206,11 @@ interface CreateQuoteDto {
     youth: boolean
     subType: string
   }
-  norwegianTravel?: {
+  norwegianTravelData?: {
     coInsured: number
     youth: boolean
   }
-  danishHomeContents?: {
+  danishHomeContentsData?: {
     street: string
     zipCode: string
     livingSpace: number
@@ -216,13 +218,13 @@ interface CreateQuoteDto {
     student: boolean
     subType: string
   }
-  danishAccident?: {
+  danishAccidentData?: {
     street: string
     zipCode: string
     coInsured: number
     student: boolean
   }
-  danishTravel?: {
+  danishTravelData?: {
     street: string
     zipCode: string
     coInsured: number

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -168,28 +168,28 @@ interface PushTokenDto {
   token: string
 }
 
-interface CreateSelfChangeQuoteDto {
+interface CreateQuoteDto {
   firstName: string
   lastName: string
   email?: string
   ssn?: string
   startDate: string
-  swedishApartment?: {
+  incompleteApartmentQuoteData?: {
     street: string
     zipCode: string
     householdSize: number
     livingSpace: number
-    type: string
+    subType: string
   }
-  swedishHouse?: {
+  incompleteHouseQuoteData?: {
     street: string
     zipCode: string
     householdSize: number
     livingSpace: number
-    ancillarySpace: number
+    ancillaryArea: number
     yearOfConstruction: number
     numberOfBathrooms: number
-    isSubleted: boolean
+    subleted: boolean
     extraBuildings: {
       type: string
       area: number
@@ -201,32 +201,32 @@ interface CreateSelfChangeQuoteDto {
     zipCode: string
     coInsured: number
     livingSpace: number
-    isYouth: boolean
-    type: string
+    youth: boolean
+    subType: string
   }
   norwegianTravel?: {
     coInsured: number
-    isYouth: boolean
+    youth: boolean
   }
   danishHomeContents?: {
     street: string
     zipCode: string
     livingSpace: number
     coInsured: number
-    isStudent: boolean
-    type: string
+    student: boolean
+    subType: string
   }
   danishAccident?: {
     street: string
     zipCode: string
     coInsured: number
-    isStudent: boolean
+    student: boolean
   }
   danishTravel?: {
     street: string
     zipCode: string
     coInsured: number
-    isStudent: boolean
+    student: boolean
   }
 }
 
@@ -889,7 +889,7 @@ const isEligibleForReferrals = async (
   }
 
 const postSelfChangeQuote = async (
-  body: CreateSelfChangeQuoteDto,
+  body: CreateQuoteDto,
   headers: ForwardHeaders,
 ): Promise<CompleteQuoteResponseDto> => {
   const data = await callApi("/underwriter/_/v1/quotes", {
@@ -906,6 +906,7 @@ export {
   setChatResponse,
   getInsurance,
   getUser,
+  UserDto,
   logoutUser,
   register,
   createProduct,
@@ -938,4 +939,5 @@ export {
   postPickedLocale,
   isEligibleForReferrals,
   postSelfChangeQuote,
+  CreateQuoteDto,
 }

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -892,14 +892,16 @@ const isEligibleForReferrals = async (
 
 const postSelfChangeQuote = async (
   body: CreateQuoteDto,
+  token: string,
   headers: ForwardHeaders,
 ): Promise<CompleteQuoteResponseDto> => {
-  const data = await callApi("/underwriter/_/v1/quotes", {
+  const data = await callApi("/underwriter/quotes", {
     mergeOptions: {
       headers: (headers as any) as RequestInit['headers'],
       method: 'POST',
       body: JSON.stringify(body),
-    }
+    },
+    token
   })
   return data.json()
 }

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -168,6 +168,74 @@ interface PushTokenDto {
   token: string
 }
 
+interface CreateSelfChangeQuoteDto {
+  firstName: string
+  lastName: string
+  email?: string
+  ssn?: string
+  startDate: string
+  swedishApartment?: {
+    street: string
+    zipCode: string
+    householdSize: number
+    livingSpace: number
+    type: string
+  }
+  swedishHouse?: {
+    street: string
+    zipCode: string
+    householdSize: number
+    livingSpace: number
+    ancillarySpace: number
+    yearOfConstruction: number
+    numberOfBathrooms: number
+    isSubleted: boolean
+    extraBuildings: {
+      type: string
+      area: number
+      hasWaterConnected: boolean
+    }[]
+  }
+  norwegianHomeContents?: {
+    street: string
+    zipCode: string
+    coInsured: number
+    livingSpace: number
+    isYouth: boolean
+    type: string
+  }
+  norwegianTravel?: {
+    coInsured: number
+    isYouth: boolean
+  }
+  danishHomeContents?: {
+    street: string
+    zipCode: string
+    livingSpace: number
+    coInsured: number
+    isStudent: boolean
+    type: string
+  }
+  danishAccident?: {
+    street: string
+    zipCode: string
+    coInsured: number
+    isStudent: boolean
+  }
+  danishTravel?: {
+    street: string
+    zipCode: string
+    coInsured: number
+    isStudent: boolean
+  }
+}
+
+interface CompleteQuoteResponseDto {
+  id: string
+  price: number
+  validTo: string
+}
+
 type CallApi = (
   url: string,
   options?: {
@@ -820,6 +888,20 @@ const isEligibleForReferrals = async (
     return json.eligible
   }
 
+const postSelfChangeQuote = async (
+  body: CreateSelfChangeQuoteDto,
+  headers: ForwardHeaders,
+): Promise<CompleteQuoteResponseDto> => {
+  const data = await callApi("/underwriter/_/v1/quotes", {
+    mergeOptions: {
+      headers: (headers as any) as RequestInit['headers'],
+      method: 'POST',
+      body: JSON.stringify(body),
+    }
+  })
+  return data.json()
+}
+
 export {
   setChatResponse,
   getInsurance,
@@ -855,4 +937,5 @@ export {
   postLanguage,
   postPickedLocale,
   isEligibleForReferrals,
+  postSelfChangeQuote,
 }

--- a/src/resolvers/index.ts
+++ b/src/resolvers/index.ts
@@ -67,6 +67,7 @@ import { selectCashbackOption } from './selectCashbackOption'
 import { geo } from './geo'
 import { startDirectDebitRegistration } from './trustly'
 import { uploadFile, uploadFiles } from './uploadFile'
+import { createSelfChangeQuote } from './selfChange'
 
 const resolvers: Resolver = {
   Query: {
@@ -119,6 +120,7 @@ const resolvers: Resolver = {
     registerBranchCampaign,
     updateLanguage,
     updatePickedLocale,
+    createSelfChangeQuote
   },
   Subscription: {
     offer: subscribeToOffer,

--- a/src/resolvers/selfChange.ts
+++ b/src/resolvers/selfChange.ts
@@ -1,0 +1,23 @@
+
+import { getUser } from '../api'
+import { Member, MutationToCreateSelfChangeQuoteResolver } from '../typings/generated-graphql-types'
+
+const createSelfChangeQuote: MutationToCreateSelfChangeQuoteResolver = async (
+    _parent,
+    _args,
+    { getToken, headers },
+): Promise<Member> => {
+    console.log("it worked");
+    const token = await getToken()
+    const member = await getUser(token, headers)
+    return {
+        id: member.memberId,
+        firstName: member.firstName,
+        lastName: member.lastName,
+        email: _args.quoteInput.email,
+        phoneNumber: member.phoneNumber,
+        features: []
+    }
+}
+
+export { createSelfChangeQuote };

--- a/src/resolvers/selfChange.ts
+++ b/src/resolvers/selfChange.ts
@@ -1,7 +1,6 @@
 
-import { getUser, postSelfChangeQuote } from '../api'
-import { SelfChangeQuoteOutput, MutationToCreateSelfChangeQuoteResolver } from '../typings/generated-graphql-types'
-
+import { getUser, UserDto, postSelfChangeQuote, CreateQuoteDto } from '../api'
+import { SelfChangeQuoteOutput, MutationToCreateSelfChangeQuoteResolver, SelfChangeQuoteInput } from '../typings/generated-graphql-types'
 
 const createSelfChangeQuote: MutationToCreateSelfChangeQuoteResolver = async (
     _parent,
@@ -9,24 +8,11 @@ const createSelfChangeQuote: MutationToCreateSelfChangeQuoteResolver = async (
     { getToken, headers },
 ): Promise<SelfChangeQuoteOutput> => {
     const input = _args.quoteInput
-    const token = await getToken()
+    const token = getToken()
     const member = await getUser(token, headers)
-
+    console.log(member);
     const result = await postSelfChangeQuote(
-        {
-            firstName: member.firstName,
-            lastName: member.lastName,
-            email: member.email,
-            ssn: member.ssn,
-            startDate: input.startDate,
-            swedishApartment: input.swedishApartment,
-            swedishHouse: input.swedishHouse,
-            norwegianHomeContents: input.norwegianHomeContents,
-            norwegianTravel: input.norwegianTravel,
-            danishHomeContents: input.danishHomeContents,
-            danishTravel: input.danishTravel,
-            danishAccident: input.danishAccident
-        },
+        buildUpstreamBody(member, input),
         headers
     )
 
@@ -34,6 +20,49 @@ const createSelfChangeQuote: MutationToCreateSelfChangeQuoteResolver = async (
         id: result.id,
         price: result.price,
         validTo: result.validTo
+    }
+}
+
+const buildUpstreamBody = (member: UserDto, input: SelfChangeQuoteInput): CreateQuoteDto => {
+    return {
+        firstName: member.firstName,
+        lastName: member.lastName,
+        email: member.email,
+        ssn: member.ssn,
+        startDate: input.startDate,
+        // The GraphQL type inputs are ALMOST the same as the upstream endpoint wants
+        // so we quickly massage them here to conform by "renaming" some fields
+        incompleteApartmentQuoteData: input.swedishApartment ? {
+            subType: input.swedishApartment.type,
+            ...input.swedishApartment
+        } : undefined,
+        incompleteHouseQuoteData: input.swedishHouse ? {
+            ancillaryArea: input.swedishHouse.ancillarySpace,
+            subleted: input.swedishHouse.isSubleted,
+            ...input.swedishHouse
+        } : undefined,
+        norwegianHomeContents: input.norwegianHomeContents ? {
+            subType: input.norwegianHomeContents.type,
+            youth: input.norwegianHomeContents.isYouth,
+            ...input.norwegianHomeContents
+        } : undefined,
+        norwegianTravel: input.norwegianTravel ? {
+            youth: input.norwegianTravel.isYouth,
+            ...input.norwegianTravel
+        } : undefined,
+        danishHomeContents: input.danishHomeContents ? {
+            student: input.danishHomeContents.isStudent,
+            subType: input.danishHomeContents.type,
+            ...input.danishHomeContents
+        } : undefined,
+        danishTravel: input.danishTravel ? {
+            student: input.danishTravel.isStudent,
+            ...input.danishTravel
+        } : undefined,
+        danishAccident: input.danishAccident ? {
+            student: input.danishAccident.isStudent,
+            ...input.danishAccident
+        }: undefined
     }
 }
 

--- a/src/resolvers/selfChange.ts
+++ b/src/resolvers/selfChange.ts
@@ -4,15 +4,14 @@ import { SelfChangeQuoteOutput, MutationToCreateSelfChangeQuoteResolver, SelfCha
 
 const createSelfChangeQuote: MutationToCreateSelfChangeQuoteResolver = async (
     _parent,
-    _args,
+    args,
     { getToken, headers },
 ): Promise<SelfChangeQuoteOutput> => {
-    const input = _args.quoteInput
     const token = getToken()
     const member = await getUser(token, headers)
-    console.log(member);
     const result = await postSelfChangeQuote(
-        buildUpstreamBody(member, input),
+        buildUpstreamBody(member, args.quoteInput),
+        token,
         headers
     )
 

--- a/src/resolvers/selfChange.ts
+++ b/src/resolvers/selfChange.ts
@@ -25,41 +25,42 @@ const createSelfChangeQuote: MutationToCreateSelfChangeQuoteResolver = async (
 
 const buildUpstreamBody = (member: UserDto, input: SelfChangeQuoteInput): CreateQuoteDto => {
     return {
+        memberId: member.memberId,
         firstName: member.firstName,
         lastName: member.lastName,
-        email: member.email,
         ssn: member.ssn,
+        birthDate: member.birthDate,
         startDate: input.startDate,
         // The GraphQL type inputs are ALMOST the same as the upstream endpoint wants
         // so we quickly massage them here to conform by "renaming" some fields
-        incompleteApartmentQuoteData: input.swedishApartment ? {
+        swedishApartmentData: input.swedishApartment ? {
             subType: input.swedishApartment.type,
             ...input.swedishApartment
         } : undefined,
-        incompleteHouseQuoteData: input.swedishHouse ? {
+        swedishHouseData: input.swedishHouse ? {
             ancillaryArea: input.swedishHouse.ancillarySpace,
             subleted: input.swedishHouse.isSubleted,
             ...input.swedishHouse
         } : undefined,
-        norwegianHomeContents: input.norwegianHomeContents ? {
+        norwegianHomeContentsData: input.norwegianHomeContents ? {
             subType: input.norwegianHomeContents.type,
             youth: input.norwegianHomeContents.isYouth,
             ...input.norwegianHomeContents
         } : undefined,
-        norwegianTravel: input.norwegianTravel ? {
+        norwegianTravelData: input.norwegianTravel ? {
             youth: input.norwegianTravel.isYouth,
             ...input.norwegianTravel
         } : undefined,
-        danishHomeContents: input.danishHomeContents ? {
+        danishHomeContentsData: input.danishHomeContents ? {
             student: input.danishHomeContents.isStudent,
             subType: input.danishHomeContents.type,
             ...input.danishHomeContents
         } : undefined,
-        danishTravel: input.danishTravel ? {
+        danishTravelData: input.danishTravel ? {
             student: input.danishTravel.isStudent,
             ...input.danishTravel
         } : undefined,
-        danishAccident: input.danishAccident ? {
+        danishAccidentData: input.danishAccident ? {
             student: input.danishAccident.isStudent,
             ...input.danishAccident
         }: undefined

--- a/src/resolvers/selfChange.ts
+++ b/src/resolvers/selfChange.ts
@@ -1,22 +1,39 @@
 
-import { getUser } from '../api'
-import { Member, MutationToCreateSelfChangeQuoteResolver } from '../typings/generated-graphql-types'
+import { getUser, postSelfChangeQuote } from '../api'
+import { SelfChangeQuoteOutput, MutationToCreateSelfChangeQuoteResolver } from '../typings/generated-graphql-types'
+
 
 const createSelfChangeQuote: MutationToCreateSelfChangeQuoteResolver = async (
     _parent,
     _args,
     { getToken, headers },
-): Promise<Member> => {
-    console.log("it worked");
+): Promise<SelfChangeQuoteOutput> => {
+    const input = _args.quoteInput
     const token = await getToken()
     const member = await getUser(token, headers)
+
+    const result = await postSelfChangeQuote(
+        {
+            firstName: member.firstName,
+            lastName: member.lastName,
+            email: member.email,
+            ssn: member.ssn,
+            startDate: input.startDate,
+            swedishApartment: input.swedishApartment,
+            swedishHouse: input.swedishHouse,
+            norwegianHomeContents: input.norwegianHomeContents,
+            norwegianTravel: input.norwegianTravel,
+            danishHomeContents: input.danishHomeContents,
+            danishTravel: input.danishTravel,
+            danishAccident: input.danishAccident
+        },
+        headers
+    )
+
     return {
-        id: member.memberId,
-        firstName: member.firstName,
-        lastName: member.lastName,
-        email: _args.quoteInput.email,
-        phoneNumber: member.phoneNumber,
-        features: []
+        id: result.id,
+        price: result.price,
+        validTo: result.validTo
     }
 }
 

--- a/src/schema.graphqls
+++ b/src/schema.graphqls
@@ -49,7 +49,7 @@ type Mutation {
   registerBranchCampaign(campaign: CampaignInput!): Boolean
   updateLanguage(input: String!): Boolean! # input should be in the format as Accept-Language header
   updatePickedLocale(pickedLocale: Locale!): Member!
-  createSelfChangeQuote(quoteInput: SelfChangeQuoteInput!): Member!
+  createSelfChangeQuote(quoteInput: SelfChangeQuoteInput!): SelfChangeQuoteOutput!
 }
 
 enum Locale {
@@ -326,19 +326,117 @@ input CampaignInput {
 }
 
 input SelfChangeQuoteInput {
-  # id: ID!
-  # currentInsurer: String
-  # startDate: LocalDate
-  # swedishApartment: CreateSwedishApartmentInput
-  # swedishHouse: CreateSwedishHouseInput
-  # norwegianHomeContents: CreateNorwegianHomeContentsInput
-  # norwegianTravel: CreateNorwegianTravelInput
-  # danishHomeContents: CreateDanishHomeContentsInput
-  # danishAccident: CreateDanishAccidentInput
-  # danishTravel: CreateDanishTravelInput
-  email: String!
-  # dataCollectionId: ID
-  # phoneNumber: String
+  startDate: LocalDate!
+  swedishApartment: SelfChangeCreateSwedishApartmentInput
+  swedishHouse: SelfChangeCreateSwedishHouseInput
+  norwegianHomeContents: SelfChangeCreateNorwegianHomeContentsInput
+  norwegianTravel: SelfChangeCreateNorwegianTravelInput
+  danishHomeContents: SelfChangeCreateDanishHomeContentsInput
+  danishAccident: SelfChangeCreateDanishAccidentInput
+  danishTravel: SelfChangeCreateDanishTravelInput
+}
+
+input SelfChangeCreateSwedishApartmentInput {
+    street: String!
+    zipCode: String!
+    householdSize: Int!
+    livingSpace: Int!
+    type: SelfChangeSwedishApartmentType!
+}
+
+input SelfChangeCreateSwedishHouseInput {
+    street: String!
+    zipCode: String!
+    householdSize: Int!
+    livingSpace: Int!
+    ancillarySpace: Int!
+    yearOfConstruction: Int!
+    numberOfBathrooms: Int!
+    isSubleted: Boolean!
+    extraBuildings: [ExtraBuildingInput!]! # Empty list represents no additional buildings. Hence null is not allowed.
+}
+
+enum SelfChangeSwedishApartmentType {
+    STUDENT_RENT
+    RENT
+    STUDENT_BRF
+    BRF
+}
+
+input ExtraBuildingInput {
+    type: ExtraBuildingType!
+    area: Int!
+    hasWaterConnected: Boolean!
+}
+
+enum ExtraBuildingType {
+    GARAGE
+    CARPORT
+    SHED
+    STOREHOUSE
+    FRIGGEBOD
+    ATTEFALL
+    OUTHOUSE
+    GUESTHOUSE
+    GAZEBO
+    GREENHOUSE
+    SAUNA
+    BARN
+    BOATHOUSE
+    OTHER
+}
+
+input SelfChangeCreateNorwegianHomeContentsInput {
+    street: String!
+    zipCode: String!
+    coInsured: Int!
+    livingSpace: Int!
+    isYouth: Boolean!
+    type: SelfChangeNorwegianHomeContentsType!
+}
+
+enum SelfChangeNorwegianHomeContentsType {
+    RENT
+    OWN
+}
+
+input SelfChangeCreateNorwegianTravelInput {
+    coInsured: Int!
+    isYouth: Boolean!
+}
+
+input SelfChangeCreateDanishHomeContentsInput {
+    street: String!
+    zipCode: String!
+    livingSpace: Int!
+    coInsured: Int!
+    isStudent: Boolean!
+    type: SelfChangeDanishHomeContentsType!
+}
+
+input SelfChangeCreateDanishAccidentInput {
+    street: String!
+    zipCode: String!
+    coInsured: Int!
+    isStudent: Boolean!
+}
+
+input SelfChangeCreateDanishTravelInput {
+    street: String!
+    zipCode: String!
+    coInsured: Int!
+    isStudent: Boolean!
+}
+
+enum SelfChangeDanishHomeContentsType {
+    RENT
+    OWN
+}
+
+type SelfChangeQuoteOutput {
+  id: ID!
+  price: Int!
+  validTo: TimeStamp!
 }
 
 enum LoggingSource {

--- a/src/schema.graphqls
+++ b/src/schema.graphqls
@@ -353,7 +353,7 @@ input SelfChangeCreateSwedishHouseInput {
     yearOfConstruction: Int!
     numberOfBathrooms: Int!
     isSubleted: Boolean!
-    extraBuildings: [ExtraBuildingInput!]! # Empty list represents no additional buildings. Hence null is not allowed.
+    extraBuildings: [SelfChangeExtraBuildingInput!]! # Empty list represents no additional buildings. Hence null is not allowed.
 }
 
 enum SelfChangeSwedishApartmentType {
@@ -363,13 +363,13 @@ enum SelfChangeSwedishApartmentType {
     BRF
 }
 
-input ExtraBuildingInput {
-    type: ExtraBuildingType!
+input SelfChangeExtraBuildingInput {
+    type: SelfChangeExtraBuildingType!
     area: Int!
     hasWaterConnected: Boolean!
 }
 
-enum ExtraBuildingType {
+enum SelfChangeExtraBuildingType {
     GARAGE
     CARPORT
     SHED

--- a/src/schema.graphqls
+++ b/src/schema.graphqls
@@ -49,6 +49,7 @@ type Mutation {
   registerBranchCampaign(campaign: CampaignInput!): Boolean
   updateLanguage(input: String!): Boolean! # input should be in the format as Accept-Language header
   updatePickedLocale(pickedLocale: Locale!): Member!
+  createSelfChangeQuote(quoteInput: SelfChangeQuoteInput!): Member!
 }
 
 enum Locale {
@@ -322,6 +323,22 @@ input CampaignInput {
   term: String
   content: String
   name: String
+}
+
+input SelfChangeQuoteInput {
+  # id: ID!
+  # currentInsurer: String
+  # startDate: LocalDate
+  # swedishApartment: CreateSwedishApartmentInput
+  # swedishHouse: CreateSwedishHouseInput
+  # norwegianHomeContents: CreateNorwegianHomeContentsInput
+  # norwegianTravel: CreateNorwegianTravelInput
+  # danishHomeContents: CreateDanishHomeContentsInput
+  # danishAccident: CreateDanishAccidentInput
+  # danishTravel: CreateDanishTravelInput
+  email: String!
+  # dataCollectionId: ID
+  # phoneNumber: String
 }
 
 enum LoggingSource {

--- a/src/typings/generated-graphql-types.ts
+++ b/src/typings/generated-graphql-types.ts
@@ -761,6 +761,7 @@ export interface Mutation {
   registerBranchCampaign?: boolean;
   updateLanguage: boolean;
   updatePickedLocale: Member;
+  createSelfChangeQuote: Member;
 }
 
 export interface CampaignInput {
@@ -878,6 +879,10 @@ export interface NorwegianBankIdAuthResponse {
 
 export interface DanishBankIdAuthResponse {
   redirectUrl: string;
+}
+
+export interface SelfChangeQuoteInput {
+  email: string;
 }
 
 export interface Subscription {
@@ -2304,6 +2309,7 @@ export interface MutationTypeResolver<TParent = undefined> {
   registerBranchCampaign?: MutationToRegisterBranchCampaignResolver<TParent>;
   updateLanguage?: MutationToUpdateLanguageResolver<TParent>;
   updatePickedLocale?: MutationToUpdatePickedLocaleResolver<TParent>;
+  createSelfChangeQuote?: MutationToCreateSelfChangeQuoteResolver<TParent>;
 }
 
 export interface MutationToLogoutResolver<TParent = undefined, TResult = boolean> {
@@ -2501,6 +2507,13 @@ export interface MutationToUpdatePickedLocaleArgs {
 }
 export interface MutationToUpdatePickedLocaleResolver<TParent = undefined, TResult = Member> {
   (parent: TParent, args: MutationToUpdatePickedLocaleArgs, context: Context, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+}
+
+export interface MutationToCreateSelfChangeQuoteArgs {
+  quoteInput: SelfChangeQuoteInput;
+}
+export interface MutationToCreateSelfChangeQuoteResolver<TParent = undefined, TResult = Member> {
+  (parent: TParent, args: MutationToCreateSelfChangeQuoteArgs, context: Context, info: GraphQLResolveInfo): TResult | Promise<TResult>;
 }
 
 export interface SessionInformationTypeResolver<TParent = SessionInformation> {

--- a/src/typings/generated-graphql-types.ts
+++ b/src/typings/generated-graphql-types.ts
@@ -916,16 +916,16 @@ export interface SelfChangeCreateSwedishHouseInput {
   yearOfConstruction: number;
   numberOfBathrooms: number;
   isSubleted: boolean;
-  extraBuildings: Array<ExtraBuildingInput>;
+  extraBuildings: Array<SelfChangeExtraBuildingInput>;
 }
 
-export interface ExtraBuildingInput {
-  type: ExtraBuildingType;
+export interface SelfChangeExtraBuildingInput {
+  type: SelfChangeExtraBuildingType;
   area: number;
   hasWaterConnected: boolean;
 }
 
-export enum ExtraBuildingType {
+export enum SelfChangeExtraBuildingType {
   GARAGE = 'GARAGE',
   CARPORT = 'CARPORT',
   SHED = 'SHED',

--- a/src/typings/generated-graphql-types.ts
+++ b/src/typings/generated-graphql-types.ts
@@ -761,7 +761,7 @@ export interface Mutation {
   registerBranchCampaign?: boolean;
   updateLanguage: boolean;
   updatePickedLocale: Member;
-  createSelfChangeQuote: Member;
+  createSelfChangeQuote: SelfChangeQuoteOutput;
 }
 
 export interface CampaignInput {
@@ -882,7 +882,117 @@ export interface DanishBankIdAuthResponse {
 }
 
 export interface SelfChangeQuoteInput {
-  email: string;
+  startDate: LocalDate;
+  swedishApartment?: SelfChangeCreateSwedishApartmentInput;
+  swedishHouse?: SelfChangeCreateSwedishHouseInput;
+  norwegianHomeContents?: SelfChangeCreateNorwegianHomeContentsInput;
+  norwegianTravel?: SelfChangeCreateNorwegianTravelInput;
+  danishHomeContents?: SelfChangeCreateDanishHomeContentsInput;
+  danishAccident?: SelfChangeCreateDanishAccidentInput;
+  danishTravel?: SelfChangeCreateDanishTravelInput;
+}
+
+export interface SelfChangeCreateSwedishApartmentInput {
+  street: string;
+  zipCode: string;
+  householdSize: number;
+  livingSpace: number;
+  type: SelfChangeSwedishApartmentType;
+}
+
+export enum SelfChangeSwedishApartmentType {
+  STUDENT_RENT = 'STUDENT_RENT',
+  RENT = 'RENT',
+  STUDENT_BRF = 'STUDENT_BRF',
+  BRF = 'BRF'
+}
+
+export interface SelfChangeCreateSwedishHouseInput {
+  street: string;
+  zipCode: string;
+  householdSize: number;
+  livingSpace: number;
+  ancillarySpace: number;
+  yearOfConstruction: number;
+  numberOfBathrooms: number;
+  isSubleted: boolean;
+  extraBuildings: Array<ExtraBuildingInput>;
+}
+
+export interface ExtraBuildingInput {
+  type: ExtraBuildingType;
+  area: number;
+  hasWaterConnected: boolean;
+}
+
+export enum ExtraBuildingType {
+  GARAGE = 'GARAGE',
+  CARPORT = 'CARPORT',
+  SHED = 'SHED',
+  STOREHOUSE = 'STOREHOUSE',
+  FRIGGEBOD = 'FRIGGEBOD',
+  ATTEFALL = 'ATTEFALL',
+  OUTHOUSE = 'OUTHOUSE',
+  GUESTHOUSE = 'GUESTHOUSE',
+  GAZEBO = 'GAZEBO',
+  GREENHOUSE = 'GREENHOUSE',
+  SAUNA = 'SAUNA',
+  BARN = 'BARN',
+  BOATHOUSE = 'BOATHOUSE',
+  OTHER = 'OTHER'
+}
+
+export interface SelfChangeCreateNorwegianHomeContentsInput {
+  street: string;
+  zipCode: string;
+  coInsured: number;
+  livingSpace: number;
+  isYouth: boolean;
+  type: SelfChangeNorwegianHomeContentsType;
+}
+
+export enum SelfChangeNorwegianHomeContentsType {
+  RENT = 'RENT',
+  OWN = 'OWN'
+}
+
+export interface SelfChangeCreateNorwegianTravelInput {
+  coInsured: number;
+  isYouth: boolean;
+}
+
+export interface SelfChangeCreateDanishHomeContentsInput {
+  street: string;
+  zipCode: string;
+  livingSpace: number;
+  coInsured: number;
+  isStudent: boolean;
+  type: SelfChangeDanishHomeContentsType;
+}
+
+export enum SelfChangeDanishHomeContentsType {
+  RENT = 'RENT',
+  OWN = 'OWN'
+}
+
+export interface SelfChangeCreateDanishAccidentInput {
+  street: string;
+  zipCode: string;
+  coInsured: number;
+  isStudent: boolean;
+}
+
+export interface SelfChangeCreateDanishTravelInput {
+  street: string;
+  zipCode: string;
+  coInsured: number;
+  isStudent: boolean;
+}
+
+export interface SelfChangeQuoteOutput {
+  id: string;
+  price: number;
+  validTo: TimeStamp;
 }
 
 export interface Subscription {
@@ -1030,6 +1140,7 @@ export interface Resolver {
   BankIdAuthResponse?: BankIdAuthResponseTypeResolver;
   NorwegianBankIdAuthResponse?: NorwegianBankIdAuthResponseTypeResolver;
   DanishBankIdAuthResponse?: DanishBankIdAuthResponseTypeResolver;
+  SelfChangeQuoteOutput?: SelfChangeQuoteOutputTypeResolver;
   Subscription?: SubscriptionTypeResolver;
   OfferEvent?: OfferEventTypeResolver;
   SignEvent?: SignEventTypeResolver;
@@ -2512,7 +2623,7 @@ export interface MutationToUpdatePickedLocaleResolver<TParent = undefined, TResu
 export interface MutationToCreateSelfChangeQuoteArgs {
   quoteInput: SelfChangeQuoteInput;
 }
-export interface MutationToCreateSelfChangeQuoteResolver<TParent = undefined, TResult = Member> {
+export interface MutationToCreateSelfChangeQuoteResolver<TParent = undefined, TResult = SelfChangeQuoteOutput> {
   (parent: TParent, args: MutationToCreateSelfChangeQuoteArgs, context: Context, info: GraphQLResolveInfo): TResult | Promise<TResult>;
 }
 
@@ -2563,6 +2674,24 @@ export interface DanishBankIdAuthResponseTypeResolver<TParent = DanishBankIdAuth
 }
 
 export interface DanishBankIdAuthResponseToRedirectUrlResolver<TParent = DanishBankIdAuthResponse, TResult = string> {
+  (parent: TParent, args: {}, context: Context, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+}
+
+export interface SelfChangeQuoteOutputTypeResolver<TParent = SelfChangeQuoteOutput> {
+  id?: SelfChangeQuoteOutputToIdResolver<TParent>;
+  price?: SelfChangeQuoteOutputToPriceResolver<TParent>;
+  validTo?: SelfChangeQuoteOutputToValidToResolver<TParent>;
+}
+
+export interface SelfChangeQuoteOutputToIdResolver<TParent = SelfChangeQuoteOutput, TResult = string> {
+  (parent: TParent, args: {}, context: Context, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+}
+
+export interface SelfChangeQuoteOutputToPriceResolver<TParent = SelfChangeQuoteOutput, TResult = number> {
+  (parent: TParent, args: {}, context: Context, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+}
+
+export interface SelfChangeQuoteOutputToValidToResolver<TParent = SelfChangeQuoteOutput, TResult = TimeStamp> {
   (parent: TParent, args: {}, context: Context, info: GraphQLResolveInfo): TResult | Promise<TResult>;
 }
 


### PR DESCRIPTION
The difference is that this quote is created after an Embark flow that does not contain all the initial onboarding information, so some of the values are filled by asking member-service for what is missing.

## Why
The upcoming embark flow that produces input for a "self change" (moving flow) quote will not contain all the data that is needed to create a quote. More specifically, it is missing things related to the member herself (name, ssn, email, etc...). In order to plug it into the underwriter quote creation, we must find a way to populate that missing information.

## What
This is a new "self change" related mutation that creates a quote by **only** taking the new quote information related to *what* the insurance contains. The mutation then internally populates the missing values by fetching them from member service, before sending them further to underwriter.

## Screenshot
![image](https://user-images.githubusercontent.com/2649932/109652234-cd376000-7b5f-11eb-95be-641992c07ea5.png)
