### PR TITLE
Personal number input on danish auth

### DIFF
--- a/src/features/auth/auth.ts
+++ b/src/features/auth/auth.ts
@@ -45,11 +45,11 @@ const norwegianBankIdAuth: MutationToNorwegianBankIdAuthResolver = async (
 
 const danishBankIdAuth: MutationToDanishBankIdAuthResolver = async (
   _parent,
-  _args,
+  { personalNumber },
   { headers, getToken },
 ) => {
   const token = getToken()
-  const danishAuthResult = await danishAuthMember(token, headers, { personalNumber: null })
+  const danishAuthResult = await danishAuthMember(token, headers, { personalNumber: personalNumber })
   const redirectUrl = danishAuthResult.redirectUrl
 
   return {

--- a/src/schema.graphqls
+++ b/src/schema.graphqls
@@ -45,7 +45,7 @@ type Mutation {
   bankIdAuth: BankIdAuthResponse! @deprecated(reason: "Use `swedishBankIdAuth`.")
   swedishBankIdAuth: BankIdAuthResponse!
   norwegianBankIdAuth(personalNumber: String): NorwegianBankIdAuthResponse!
-  danishBankIdAuth: DanishBankIdAuthResponse!
+  danishBankIdAuth(personalNumber: String!): DanishBankIdAuthResponse!
   registerBranchCampaign(campaign: CampaignInput!): Boolean
   updateLanguage(input: String!): Boolean! # input should be in the format as Accept-Language header
   updatePickedLocale(pickedLocale: Locale!): Member!

--- a/src/typings/generated-graphql-types.ts
+++ b/src/typings/generated-graphql-types.ts
@@ -2596,8 +2596,11 @@ export interface MutationToNorwegianBankIdAuthResolver<TParent = undefined, TRes
   (parent: TParent, args: MutationToNorwegianBankIdAuthArgs, context: Context, info: GraphQLResolveInfo): TResult | Promise<TResult>;
 }
 
+export interface MutationToDanishBankIdAuthArgs {
+  personalNumber: string;
+}
 export interface MutationToDanishBankIdAuthResolver<TParent = undefined, TResult = DanishBankIdAuthResponse> {
-  (parent: TParent, args: {}, context: Context, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+  (parent: TParent, args: MutationToDanishBankIdAuthArgs, context: Context, info: GraphQLResolveInfo): TResult | Promise<TResult>;
 }
 
 export interface MutationToRegisterBranchCampaignArgs {


### PR DESCRIPTION
Added personal number as input on `danishBankIdAuth` mutation this is to enable simple sign. 

I know this is breaking the schema but the mutation is not used in prod and for me, it feels better to be explicit that we will need `personalNumber` when authenticating in Denmark. Please let me know if you don't agree and we can discuss it. 