### PR TITLE
Build a little more streamlined alternative to the existing 'callApi' upstream functions

### DIFF
--- a/src/api/httpClient.ts
+++ b/src/api/httpClient.ts
@@ -32,7 +32,7 @@ export const createContextfulHttpClient = (
 
     const requestOptions: RequestInit = {
       method: method,
-      body: body !== undefined ? JSON.stringify(body) : body,
+      body: body ? JSON.stringify(body) : body,
       headers: headers,
     }
 

--- a/src/api/httpClient.ts
+++ b/src/api/httpClient.ts
@@ -1,5 +1,6 @@
 
 import fetch, { RequestInit, Response } from 'node-fetch'
+import { TokenProvider } from '../context'
 
 /**
  * A client that can perform upstream HTTP calls. It can be assumed
@@ -18,7 +19,7 @@ export interface HttpClient {
  */
 export const createContextfulHttpClient = (
   baseUrl: string,
-  getToken: () => string,
+  getToken: TokenProvider,
   forwardHeaders: { [key: string]: string }
 ): HttpClient => {
   const call = async (url: string, method: string, body: any | undefined = undefined): Promise<Response> => {

--- a/src/api/httpClient.ts
+++ b/src/api/httpClient.ts
@@ -17,14 +17,14 @@ export interface HttpClient {
  */
 export const createContextfulHttpClient = (
   baseUrl: string,
-  token: string,
+  getToken: () => string,
   forwardHeaders: { [key: string]: string }
 ): HttpClient => {
   const call = async (url: string, method: string, body: any | undefined = undefined): Promise<Response> => {
     const headers: { [key: string]: string } = {
       ...forwardHeaders,
       Accept: 'application/json',
-      Authorization: `Bearer ${token}`
+      Authorization: `Bearer ${getToken()}`
     }
     if (body) {
       headers['Content-Type'] = 'application/json'

--- a/src/api/httpClient.ts
+++ b/src/api/httpClient.ts
@@ -1,0 +1,51 @@
+
+import fetch, { RequestInit, Response } from 'node-fetch'
+
+/**
+ * A client that can perform upstream HTTP calls.
+ */
+export interface HttpClient {
+  get(url: string): Promise<Response>
+  post(url: string, body: any): Promise<Response>
+  put(url: string, body: any): Promise<Response>
+  delete(url: string): Promise<Response>
+}
+
+/**
+ * Create a HttpClient that comes with a pre-packaged base-url,
+ * auth token and headers.
+ */
+export const createContextfulHttpClient = (
+  baseUrl: string,
+  token: string,
+  forwardHeaders: { [key: string]: string }
+): HttpClient => {
+  const call = async (url: string, method: string, body: any | undefined = undefined): Promise<Response> => {
+    const headers: { [key: string]: string } = {
+      ...forwardHeaders,
+      Accept: 'application/json',
+    }
+    if (body) {
+      headers['Content-Type'] = 'application/json'
+    }
+    if (token) {
+      headers.Authorization = `Bearer ${token}`
+    }
+
+    const requestOptions: RequestInit = {
+      method: method,
+      body: body !== undefined ? JSON.stringify(body) : body,
+      headers: headers,
+    }
+
+    const res = await fetch(`${baseUrl}${url}`, requestOptions)
+    return res
+  }
+
+  return {
+    get: (url) => call(url, "GET"),
+    post: (url, body) => call(url, "POST", body),
+    put: (url, body) => call(url, "PUT", body),
+    delete: (url) => call(url, "DELETE"),
+  }
+}

--- a/src/api/httpClient.ts
+++ b/src/api/httpClient.ts
@@ -32,7 +32,7 @@ export const createContextfulHttpClient = (
 
     const requestOptions: RequestInit = {
       method: method,
-      body: body ? JSON.stringify(body) : body,
+      body: body ? JSON.stringify(body) : undefined,
       headers: headers,
     }
 

--- a/src/api/httpClient.ts
+++ b/src/api/httpClient.ts
@@ -2,7 +2,8 @@
 import fetch, { RequestInit, Response } from 'node-fetch'
 
 /**
- * A client that can perform upstream HTTP calls.
+ * A client that can perform upstream HTTP calls. It can be assumed
+ * to contain the necessary headers to fire calls in the current context.
  */
 export interface HttpClient {
   get(url: string): Promise<Response>

--- a/src/api/httpClient.ts
+++ b/src/api/httpClient.ts
@@ -24,12 +24,10 @@ export const createContextfulHttpClient = (
     const headers: { [key: string]: string } = {
       ...forwardHeaders,
       Accept: 'application/json',
+      Authorization: `Bearer ${token}`
     }
     if (body) {
       headers['Content-Type'] = 'application/json'
-    }
-    if (token) {
-      headers.Authorization = `Bearer ${token}`
     }
 
     const requestOptions: RequestInit = {
@@ -39,6 +37,13 @@ export const createContextfulHttpClient = (
     }
 
     const res = await fetch(`${baseUrl}${url}`, requestOptions)
+
+    if (res.status >= 400) { // TODO: include custom status validation when needed
+      throw new Error(
+        `API error - status: ${res.status}, body: ${JSON.stringify(await res.text(), null, 4)}`
+      )
+    }
+
     return res
   }
 

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -169,15 +169,6 @@ interface PushTokenDto {
   token: string
 }
 
-interface ContractMarketInfoDto {
-  market: string,
-  preferredCurrency: string
-}
-
-interface SelfChangeEligibilityDto {
-  blockers: string[]
-}
-
 export interface CreateQuoteDto {
   memberId: String
   firstName: string
@@ -899,34 +890,6 @@ const isEligibleForReferrals = async (
     return json.eligible
   }
 
-const getContractMarketInfo = async (
-  token: string,
-  headers: ForwardHeaders
-): Promise<ContractMarketInfoDto> => {
-  const data = await callApi('/productPricing/contracts/market-info/', {
-    mergeOptions: {
-      headers: (headers as any) as RequestInit['headers'],
-    },
-    token,
-  })
-
-  return await data.json()
-}
-
-const getSelfChangeEligibility = async (
-  token: string,
-  headers: ForwardHeaders
-): Promise<SelfChangeEligibilityDto> => {
-  const data = await callApi('/productPricing/contracts/selfChange/eligibility', {
-    mergeOptions: {
-      headers: (headers as any) as RequestInit['headers'],
-    },
-    token,
-  })
-
-  return await data.json()
-}
-
 const postSelfChangeQuote = async (
   body: CreateQuoteDto,
   token: string,
@@ -978,7 +941,5 @@ export {
   postLanguage,
   postPickedLocale,
   isEligibleForReferrals,
-  getContractMarketInfo,
-  getSelfChangeEligibility,
   postSelfChangeQuote,
 }

--- a/src/api/upstream.ts
+++ b/src/api/upstream.ts
@@ -1,6 +1,6 @@
 import { createProductPricingClient, ProductPricingClient } from './upstreams/productPricing';
 import { createContextfulHttpClient, HttpClient } from './httpClient';
-import { ForwardHeaders } from '../context';
+import { TokenProvider, ForwardHeaders } from '../context';
 import * as config from '../config'
 
 /**
@@ -19,7 +19,7 @@ export interface Upstream {
 }
 
 export const createUpstream = (
-    token: () => string,
+    token: TokenProvider,
     headers: ForwardHeaders
 ): Upstream => {
 

--- a/src/api/upstream.ts
+++ b/src/api/upstream.ts
@@ -19,7 +19,7 @@ export interface Upstream {
 }
 
 export const createUpstream = (
-    token: string,
+    token: () => string,
     headers: ForwardHeaders
 ): Upstream => {
 

--- a/src/api/upstream.ts
+++ b/src/api/upstream.ts
@@ -14,14 +14,14 @@ import * as config from '../config'
  * const quote = await upstream.underwriter.getQuote("id")
  * ```
  */
-export interface UpstreamApi {
+export interface Upstream {
     productPricing: ProductPricingClient
 }
 
-export const createUpstreamApi = (
+export const createUpstream = (
     token: string,
     headers: ForwardHeaders
-): UpstreamApi => {
+): Upstream => {
 
     const createHttpClient = (remotePathPrefix: string, localPort: number): HttpClient => {
         const allHeaders = (headers as any) as { [key: string]: string }

--- a/src/api/upstream.ts
+++ b/src/api/upstream.ts
@@ -26,7 +26,7 @@ export const createUpstream = (
     const createHttpClient = (remotePathPrefix: string, localPort: number): HttpClient => {
         const allHeaders = (headers as any) as { [key: string]: string }
 
-        const baseUrl: string = config.UPSTREAM_MODE == "local"
+        const baseUrl: string = config.UPSTREAM_MODE === "local"
             ? `http://localhost:${localPort}`
             : `${config.BASE_URL}${remotePathPrefix}`
         if (config.UPSTREAM_MODE == "local" && config.LOCAL_MEMBERID_OVERRIDE) {

--- a/src/api/upstreamApi.ts
+++ b/src/api/upstreamApi.ts
@@ -1,0 +1,44 @@
+import { createProductPricingClient, ProductPricingClient } from './upstreams/productPricing';
+import { createContextfulHttpClient, HttpClient } from './httpClient';
+import { ForwardHeaders } from '../context';
+import * as config from '../config'
+
+/**
+ * An umbrella type that groups different upstream services, making it
+ * easy to inject in the Context.
+ *
+ * Then it can be used in functions like
+ * ```typescript
+ * { upstream } // injected into GraphQL resolve function for instance
+ * ...
+ * const quote = await upstream.underwriter.getQuote("id")
+ * ```
+ */
+export interface UpstreamApi {
+    productPricing: ProductPricingClient
+}
+
+export const createUpstreamApi = (
+    token: string,
+    headers: ForwardHeaders
+): UpstreamApi => {
+
+    const createHttpClient = (remotePathPrefix: string, localPort: number): HttpClient => {
+        const allHeaders = (headers as any) as { [key: string]: string }
+
+        let baseUrl: string = `${config.BASE_URL}${remotePathPrefix}`
+        if (config.UPSTREAM_MODE == "local") {
+            baseUrl = `http://localhost:${localPort}`
+            if (config.LOCAL_MEMBERID_OVERRIDE) {
+                allHeaders["Hedvig.token"] = config.LOCAL_MEMBERID_OVERRIDE as string
+            }
+        }
+        return createContextfulHttpClient(baseUrl, token, allHeaders)
+    }
+
+    return {
+        productPricing: createProductPricingClient(
+            createHttpClient("/productPricing", 4085)
+        )
+    }
+}

--- a/src/api/upstreamApi.ts
+++ b/src/api/upstreamApi.ts
@@ -26,12 +26,11 @@ export const createUpstreamApi = (
     const createHttpClient = (remotePathPrefix: string, localPort: number): HttpClient => {
         const allHeaders = (headers as any) as { [key: string]: string }
 
-        let baseUrl: string = `${config.BASE_URL}${remotePathPrefix}`
-        if (config.UPSTREAM_MODE == "local") {
-            baseUrl = `http://localhost:${localPort}`
-            if (config.LOCAL_MEMBERID_OVERRIDE) {
-                allHeaders["Hedvig.token"] = config.LOCAL_MEMBERID_OVERRIDE as string
-            }
+        const baseUrl: string = config.UPSTREAM_MODE == "local"
+            ? `http://localhost:${localPort}`
+            : `${config.BASE_URL}${remotePathPrefix}`
+        if (config.UPSTREAM_MODE == "local" && config.LOCAL_MEMBERID_OVERRIDE) {
+            allHeaders["Hedvig.token"] = config.LOCAL_MEMBERID_OVERRIDE as string
         }
         return createContextfulHttpClient(baseUrl, token, allHeaders)
     }

--- a/src/api/upstreams/productPricing.ts
+++ b/src/api/upstreams/productPricing.ts
@@ -1,0 +1,29 @@
+
+import { HttpClient } from '../httpClient'
+
+export interface ProductPricingClient {
+  getContractMarketInfo(): Promise<ContractMarketInfoDto>
+  getSelfChangeEligibility(): Promise<SelfChangeEligibilityDto>
+}
+
+interface ContractMarketInfoDto {
+  market: string,
+  preferredCurrency: string
+}
+
+interface SelfChangeEligibilityDto {
+  blockers: string[]
+}
+
+export const createProductPricingClient = (client: HttpClient): ProductPricingClient => {
+  return {
+    getContractMarketInfo: async () => {
+      const res = await client.get("/contracts/market-info")
+      return res.json()
+    },
+    getSelfChangeEligibility: async () => {
+      const res = await client.get("/contracts/selfChange/eligibility")
+      return res.json()
+    }
+  }
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,7 @@
 const BASE_URL = process.env.BASE_URL || 'https://gateway.test.hedvig.com'
 const PORT = Number(process.env.PORT) || 4000
+const UPSTREAM_MODE = process.env.UPSTREAM_MODE || 'remote'
+const LOCAL_MEMBERID_OVERRIDE: string | undefined = process.env.LOCAL_MEMBERID_OVERRIDE
 const PLAYGROUND_ENABLED =
   (process.env.PLAYGROUND_ENABLED &&
     process.env.PLAYGROUND_ENABLED === 'true') ||
@@ -29,6 +31,8 @@ const ANGEL_URL = process.env.ANGEL_URL || ''
 export {
   BASE_URL,
   PORT,
+  UPSTREAM_MODE,
+  LOCAL_MEMBERID_OVERRIDE,
   PLAYGROUND_ENABLED,
   REDIS_HOSTNAME,
   REDIS_PORT,

--- a/src/context.ts
+++ b/src/context.ts
@@ -48,7 +48,7 @@ const getWebContext = (graphCMSSchema: GraphQLSchema) => async ({
     headers,
     remoteIp:
       checkedCtx.get('x-forwarded-for') || ipv6toipv4(checkedCtx.request.ip),
-    upstream: createUpstream(getToken(), headers)
+    upstream: createUpstream(getToken, headers)
   }
 }
 
@@ -81,7 +81,7 @@ const getWebSocketContext = (graphCMSSchema: GraphQLSchema) => (
     remoteIp:
       headers['X-Forwarded-For'] ||
       (context.request.connection.address() as string),
-    upstream: createUpstream(getToken(), headers)
+    upstream: createUpstream(getToken, headers)
   }
 }
 

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,4 +1,4 @@
-import { createUpstream, Upstream } from './api/Upstream';
+import { createUpstream, Upstream } from './api/upstream';
 import { AuthenticationError } from 'apollo-server-core'
 import { GraphQLSchema } from 'graphql'
 import * as Koa from 'koa'

--- a/src/context.ts
+++ b/src/context.ts
@@ -45,7 +45,7 @@ const getWebContext = (graphCMSSchema: GraphQLSchema) => async ({
   return {
     getToken,
     graphCMSSchema,
-    headers: headers,
+    headers,
     remoteIp:
       checkedCtx.get('x-forwarded-for') || ipv6toipv4(checkedCtx.request.ip),
     upstream: createUpstreamApi(getToken(), headers)

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,4 +1,4 @@
-import { createUpstreamApi, UpstreamApi } from './api/upstreamApi';
+import { createUpstream, Upstream } from './api/Upstream';
 import { AuthenticationError } from 'apollo-server-core'
 import { GraphQLSchema } from 'graphql'
 import * as Koa from 'koa'
@@ -12,7 +12,7 @@ interface Context {
   headers: ForwardHeaders
   graphCMSSchema: GraphQLSchema
   remoteIp: string,
-  upstream: UpstreamApi
+  upstream: Upstream
 }
 
 interface ForwardHeaders {
@@ -48,7 +48,7 @@ const getWebContext = (graphCMSSchema: GraphQLSchema) => async ({
     headers,
     remoteIp:
       checkedCtx.get('x-forwarded-for') || ipv6toipv4(checkedCtx.request.ip),
-    upstream: createUpstreamApi(getToken(), headers)
+    upstream: createUpstream(getToken(), headers)
   }
 }
 
@@ -81,7 +81,7 @@ const getWebSocketContext = (graphCMSSchema: GraphQLSchema) => (
     remoteIp:
       headers['X-Forwarded-For'] ||
       (context.request.connection.address() as string),
-    upstream: createUpstreamApi(getToken(), headers)
+    upstream: createUpstream(getToken(), headers)
   }
 }
 

--- a/src/context.ts
+++ b/src/context.ts
@@ -8,11 +8,15 @@ import { ipv6toipv4 } from './utils/ip'
 import { notNullable } from './utils/nullables'
 
 interface Context {
-  getToken: () => string
+  getToken: TokenProvider
   headers: ForwardHeaders
   graphCMSSchema: GraphQLSchema
   remoteIp: string,
   upstream: Upstream
+}
+
+interface TokenProvider {
+  (): string
 }
 
 interface ForwardHeaders {
@@ -85,4 +89,4 @@ const getWebSocketContext = (graphCMSSchema: GraphQLSchema) => (
   }
 }
 
-export { getWebContext, getWebSocketContext, Context, ForwardHeaders }
+export { getWebContext, getWebSocketContext, Context, TokenProvider, ForwardHeaders }

--- a/src/resolvers/selfChange.ts
+++ b/src/resolvers/selfChange.ts
@@ -1,5 +1,5 @@
 
-import { getUser, UserDto, getContractMarketInfo, getSelfChangeEligibility, postSelfChangeQuote, CreateQuoteDto } from '../api'
+import { getUser, UserDto, postSelfChangeQuote, CreateQuoteDto } from '../api'
 import {
     SelfChangeQuoteOutput,
     MutationToCreateSelfChangeQuoteResolver,
@@ -11,17 +11,15 @@ import {
 const selfChangeEligibility: QueryToSelfChangeEligibilityResolver = async (
     _parent,
     _args,
-    { getToken, headers },
+    { upstream },
 ): Promise<SelfChangeEligibility> => {
-    const token = getToken()
-
-    const eligibility = await getSelfChangeEligibility(token, headers)
+    const eligibility = await upstream.productPricing.getSelfChangeEligibility()
     const isEligible = eligibility.blockers.length == 0
     if (!isEligible) {
         return { blockers: [], embarkStoryId: undefined }
     }
 
-    const marketInfo = await getContractMarketInfo(token, headers)
+    const marketInfo = await upstream.productPricing.getContractMarketInfo()
     const storiesByMarket = new Map<String, string>()
         .set("SWEDEN", "moving-flow-SE")
         .set("NORWAY", "moving-flow-NO")

--- a/src/resolvers/selfChange.ts
+++ b/src/resolvers/selfChange.ts
@@ -8,6 +8,11 @@ import {
     SelfChangeEligibility
 } from '../typings/generated-graphql-types'
 
+const storiesByMarket: { [key: string]: string } = {
+    "SWEDEN": "moving-flow-SE",
+    "NORWAY": "moving-flow-NO"
+}
+
 const selfChangeEligibility: QueryToSelfChangeEligibilityResolver = async (
     _parent,
     _args,
@@ -20,13 +25,9 @@ const selfChangeEligibility: QueryToSelfChangeEligibilityResolver = async (
     }
 
     const marketInfo = await upstream.productPricing.getContractMarketInfo()
-    const storiesByMarket = new Map<String, string>()
-        .set("SWEDEN", "moving-flow-SE")
-        .set("NORWAY", "moving-flow-NO")
-
     return {
         blockers: [], // is deprecated
-        embarkStoryId: storiesByMarket.get(marketInfo.market.toUpperCase())
+        embarkStoryId: storiesByMarket[marketInfo.market.toUpperCase()]
     }
 }
 


### PR DESCRIPTION
## Background
Calling simple upstream endpoints in Giraffe is somewhat cumbersome. When writing a resolver function for GraphQL, we have to dig out somewhat low level constructs like `getToken` and `headers`, which we forward to every upstream call. We never need to specifically work with these in any particular way, we just need to forward them.

Similarly, when declaring new upstream calls, the same object is constructed and copy pasted between each single call:
```typescript
{
    mergeOptions: {
      headers: (headers as any) as RequestInit['headers'],
      method: 'POST',
      body: JSON.stringify(body),
    },
    token
  }
```

There was also no way to actually point the `callApi` implementation towards the local environment, since it depended on a `BASE_URL` approach, which wasn't properly compatible with how we use ports to discern services locally, but path prefixes when doing so remote.

Lastly, having all the API calls as top level functions from the same file generates quite a lot of imports for each method.

Wouldn't it be nicer if doing upstream calls was less cumbersome and reminded you of working with `FeignClients`? :) 

## Solution
This suggestion basically is built on top of having `HttpClient` types that has `callApi`:esque functions that **already has the token and headers pre-packaged**. On top of that, there are types leveraging that client to build nice top level functions for specific API calls. These are sorted into which upstream service they target, and are grouped in different files.

This injected "umbrella type" lives inside the context each resolver receives, and contains a `ProductPricingClient` for now:
```typescript
export interface Upstream {
    productPricing: ProductPricingClient
    // TODO: add underwriter, memberService and friends
}
```

```typescript
// no token/headers needed, that's baked into the implementation of this type
export interface ProductPricingClient {
  getContractMarketInfo(): Promise<ContractMarketInfoDto>
  getSelfChangeEligibility(): Promise<SelfChangeEligibilityDto>
}
```

And here's what it looks like at the call site:
```typescript
const myGraphQLQuery: QueryToSomething = async (
    _parent,
    _args,
    { upstream }, // look!!! an `Upstream` 
): Promise<ResultThingy> => {
  // neat!
  // and the best part is I don't need to spell out any imports to get this beyond the auto-generated
  // one from the GraphQL resolver signature 
  const info = await upstream.productPricing.getContractMarketInfo()
}
```

### Adding new upstream calls
Based on this, it's super easy to add new upstream calls, especially if there's already a client for the service you're targeting:

Let's say we want to add the ability to GET and POST animals to an animal API. Here we go:
```typescript
// declare some data types:
interface AnimalClient {
  get(id: string): Promise<Animal>
  create(animal: Animal): Promise<Animal>
}

interface Animal {
  id?: string
  name: string
}

// and later in the implementation
{ // client here is the injected HttpClient
  get: async (id) => {
    const res = await client.get(`/animals/${id}`)
    return res.json()
  },
  create: async (animal) => {
    const res = await client.post("/animals", animal)
    return res.json()
  }
}

```

### Bonus features
- This thing can call your local machine, `callApi` couldn't due to its baseUrl setup
- Whether you want to target the local upstream or staging can be toggled using `UPSTREAM_MODE="local|remote"` in `.env`
- When targeting your local environment, you can pretend to be a specific user by setting `LOCAL_MEMBERID_OVERRIDE=<member-id>` in `.env`