### PR TITLE
MX-71: Enable a way to configure whether upstream schema stitching should happen or not during development.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,7 +27,7 @@ UPSTREAM_MODE=remote
 # When running towards local machines, avoiding api-gateway, this
 # can be used to explicitly set a Hedvig.token header.
 # Requires UPSTREAM_MODE=local
-LOCAL_MEMBERID_OVERRIDE=155641845
+LOCAL_MEMBERID_OVERRIDE=12341234
 
 # Configure how schema introspection should be done at the start of the service.
 # Modes:

--- a/.env.example
+++ b/.env.example
@@ -18,3 +18,20 @@ EMBARK_GRAPHQL_ENDPOINT=http://embark/graphql
 EMBARK_FORMAT_ENDPOINT=http://embark/format.js
 KEY_GEAR_GRAPHQL_ENDPOINT=http://keygear/graphql
 AVAILABLE_LOCALES=en_SE,en_DK,en_NO,sv_SE,nb_NO,da_DK
+
+# Configure whether regular upstream calls target your local machine
+# or the remote server configured by BASE_URL
+# either local|remote - remote is default
+UPSTREAM_MODE=remote
+
+# When running towards local machines, avoiding api-gateway, this
+# can be used to explicitly set a Hedvig.token header.
+# Requires UPSTREAM_MODE=local
+LOCAL_MEMBERID_OVERRIDE=155641845
+
+# Configure how schema introspection should be done at the start of the service.
+# Modes:
+# - full: introspect all services, fail to start if any of them fail
+# - fault-tolerant: introspect all services, but continue if any of them fail
+# - none: don't do any introspection, useful when only working with the Giraffe-local schema
+GRAPHQL_SCHEMA_INTROSPECTION_MODE=full

--- a/.env.example
+++ b/.env.example
@@ -34,4 +34,6 @@ LOCAL_MEMBERID_OVERRIDE=12341234
 # - full: introspect all services, fail to start if any of them fail
 # - fault-tolerant: introspect all services, but continue if any of them fail
 # - none: don't do any introspection, useful when only working with the Giraffe-local schema
-GRAPHQL_SCHEMA_INTROSPECTION_MODE=full
+#
+# Default is fault-tolerant when NODE_ENV=development, full otherwise
+GRAPHQL_SCHEMA_INTROSPECTION_MODE=fault-tolerant

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "main": "dist/index.js",
   "scripts": {
     "start": "node .",
-    "dev": "ts-node src/index.ts",
+    "dev": "ts-node --transpile-only src/index.ts",
     "build": "tsc && cp src/schema.graphqls dist/schema.graphqls && mkdir dist/translations && cp -r src/translations/*.json dist/translations",
     "watch": "concurrently -n \"ts-node,graphqls\" \"nodemon -e ts -w ./src -x yarn dev\" \"nodemon -e graphqls -w ./src -x yarn generate:schema-types\"",
     "lint": "tslint **/*.ts",

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,7 +3,7 @@ const PORT = Number(process.env.PORT) || 4000
 const UPSTREAM_MODE = process.env.UPSTREAM_MODE || 'remote'
 const LOCAL_MEMBERID_OVERRIDE: string | undefined = process.env.LOCAL_MEMBERID_OVERRIDE
 const GRAPHQL_SCHEMA_INTROSPECTION_MODE = process.env.NODE_ENV === 'development'
-  ? process.env.GRAPHQL_SCHEMA_INTROSPECTION_MODE || 'full'
+  ? process.env.GRAPHQL_SCHEMA_INTROSPECTION_MODE || 'fault-tolerant'
   : 'full'
 
 const PLAYGROUND_ENABLED =

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,7 +2,10 @@ const BASE_URL = process.env.BASE_URL || 'https://gateway.test.hedvig.com'
 const PORT = Number(process.env.PORT) || 4000
 const UPSTREAM_MODE = process.env.UPSTREAM_MODE || 'remote'
 const LOCAL_MEMBERID_OVERRIDE: string | undefined = process.env.LOCAL_MEMBERID_OVERRIDE
-const GRAPHQL_SCHEMA_INTROSPECTION_MODE = process.env.GRAPHQL_SCHEMA_INTROSPECTION_MODE || 'full'
+const GRAPHQL_SCHEMA_INTROSPECTION_MODE = process.env.NODE_ENV === 'development'
+  ? process.env.GRAPHQL_SCHEMA_INTROSPECTION_MODE || 'full'
+  : 'full'
+
 const PLAYGROUND_ENABLED =
   (process.env.PLAYGROUND_ENABLED &&
     process.env.PLAYGROUND_ENABLED === 'true') ||

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,6 +2,7 @@ const BASE_URL = process.env.BASE_URL || 'https://gateway.test.hedvig.com'
 const PORT = Number(process.env.PORT) || 4000
 const UPSTREAM_MODE = process.env.UPSTREAM_MODE || 'remote'
 const LOCAL_MEMBERID_OVERRIDE: string | undefined = process.env.LOCAL_MEMBERID_OVERRIDE
+const GRAPHQL_SCHEMA_INTROSPECTION_MODE = process.env.GRAPHQL_SCHEMA_INTROSPECTION_MODE || 'full'
 const PLAYGROUND_ENABLED =
   (process.env.PLAYGROUND_ENABLED &&
     process.env.PLAYGROUND_ENABLED === 'true') ||
@@ -48,5 +49,6 @@ export {
   SENTRY_ENV,
   GOOGLE_CLOUD,
   ANGEL_URL,
-  AVAILABLE_LOCALES
+  AVAILABLE_LOCALES,
+  GRAPHQL_SCHEMA_INTROSPECTION_MODE,
 }

--- a/src/resolvers/cross-schema/index.ts
+++ b/src/resolvers/cross-schema/index.ts
@@ -3,19 +3,195 @@ import { IResolvers } from 'graphql-tools'
 import quoteDetailsTable, { crossSchemaExtensions as quoteDetailsCrossSchemaExtensions } from './quoteDetailsTable'
 import quoteDisplayName, { crossSchemaExtensions as quoteDisplayNameCrossSchemaExtensions } from './quoteDisplayName'
 
-export const crossSchemaExtensions = `
+export enum SchemaIdentifier {
+  GRAPH_CMS = "graph-cms",
+  CONTENT_SERVICE = "content-service",
+  API_GATEWAY = "api-gateway",
+  PAYMENT_SERVICE = "payment-service",
+  PRODUCT_PRICING = "product-pricing",
+  ACCOUNT_SERVICE = "account-service",
+  UNDERWRITER = "underwriter",
+  EMBARK = "embark",
+  KEY_GEAR = "key-gear",
+  LOOKUP_SERVICE = "lookup-service",
+}
+
+interface CrossSchemaExtension {
+  dependencies: SchemaIdentifier[]
+  content: string,
+  resolvers(schemas: (identifier: SchemaIdentifier) => GraphQLSchema): IResolvers
+}
+
+export const getCrossSchemaExtensions = (
+  schemas: Map<SchemaIdentifier, GraphQLSchema>
+): { extension: string, resolvers: IResolvers } => {
+
+  const allExtensions: CrossSchemaExtension[] = [
+    keyGearExtension,
+    contractExtension,
+    quotesExtension,
+    embarkExtension,
+  ]
+  const applicable = allExtensions.filter(extension => {
+    const missing = extension.dependencies.filter(id => !schemas.get(id))
+    return missing.length === 0
+  })
+
+  return {
+    extension: applicable.map(ext => ext.content).join(""),
+    resolvers: applicable.reduce((acc, ext) => {
+      const res = ext.resolvers((id) => schemas.get(id)!)
+      return {...acc, ...res}
+    }, {})
+  }
+}
+
+const keyGearExtension: CrossSchemaExtension = {
+  dependencies: [SchemaIdentifier.GRAPH_CMS, SchemaIdentifier.KEY_GEAR],
+  content: `
   extend type KeyGearItem {
     covered: [KeyGearItemCoverage!]!
     exceptions: [KeyGearItemCoverage!]!
   }
+  `,
+  resolvers: (schemas) => ({
+    KeyGearItem: {
+      covered: {
+        fragment: `fragment KeyGearCrossSchemaFragment on KeyGearItem { category }`,
+        resolve: (keyGearItem: KeyGearItem, _args, context, info) => {
+          return info.mergeInfo.delegateToSchema({
+            schema: schemas(SchemaIdentifier.GRAPH_CMS),
+            operation: 'query',
+            fieldName: 'keyGearItemCoverages',
+            args: {
+              where: {
+                id_in: getCoveredIds(keyGearItem.category),
+              },
+            },
+            context,
+            info,
+          })
+        },
+      },
+      exceptions: {
+        fragment: `fragment KeyGearCrossSchemaFragment on KeyGearItem { category }`,
+        resolve: (keyGearItem: KeyGearItem, _args, context, info) => {
+          return info.mergeInfo.delegateToSchema({
+            schema: schemas(SchemaIdentifier.GRAPH_CMS),
+            operation: 'query',
+            fieldName: 'keyGearItemCoverages',
+            args: {
+              where: {
+                id_in: getExceptionIds(keyGearItem.category),
+              },
+            },
+            context,
+            info,
+          })
+        },
+      },
+    }
+  })
+}
 
+const contractExtension: CrossSchemaExtension = {
+  dependencies: [SchemaIdentifier.CONTENT_SERVICE, SchemaIdentifier.PRODUCT_PRICING],
+  content: `
   extend type Contract {
     perils(locale: Locale!): [PerilV2!]!
     insurableLimits(locale: Locale!): [InsurableLimit!]!
     termsAndConditions(locale: Locale!): InsuranceTerm!
     insuranceTerms(locale: Locale!): [InsuranceTerm!]!
   }
+  `,
+  resolvers: (schemas) => ({
+    Contract: {
+      perils: {
+        fragment: `fragment ContractCrossSchemaFragment on Contract { typeOfContract }`,
+        resolve: (contract: Contract, args: PerilsArgs, context, info) => {
+          return info.mergeInfo.delegateToSchema({
+            schema: schemas(SchemaIdentifier.CONTENT_SERVICE),
+            operation: 'query',
+            fieldName: 'perils',
+            args: {
+              contractType: contract.typeOfContract,
+              locale: args.locale,
+            },
+            context,
+            info,
+          })
+        },
+      },
+      insurableLimits: {
+        fragment: `fragment CompleteQuoteCrossSchemaFragment on Contract { typeOfContract }`,
+        resolve: (
+          contract: Contract,
+          args: InsurableLimitArgs,
+          context,
+          info,
+        ) => {
+          return info.mergeInfo.delegateToSchema({
+            schema: schemas(SchemaIdentifier.CONTENT_SERVICE),
+            operation: 'query',
+            fieldName: 'insurableLimits',
+            args: {
+              contractType: contract.typeOfContract,
+              locale: args.locale,
+            },
+            context,
+            info,
+          })
+        },
+      },
+      termsAndConditions: {
+        fragment: `fragment CompleteQuoteCrossSchemaFragment on Contract { typeOfContract }`,
+        resolve: (
+          contract: Contract,
+          args: TermsAndConditionsArgs,
+          context,
+          info,
+        ) => {
+          return info.mergeInfo.delegateToSchema({
+            schema: schemas(SchemaIdentifier.CONTENT_SERVICE),
+            operation: 'query',
+            fieldName: 'termsAndConditions',
+            args: {
+              contractType: contract.typeOfContract,
+              locale: args.locale,
+            },
+            context,
+            info,
+          })
+        },
+      },
+      insuranceTerms: {
+        fragment: `fragment CompleteQuoteCrossSchemaFragment on Contract { typeOfContract }`,
+        resolve: (
+          contract: Contract,
+          args: InsuranceTermsArgs,
+          context,
+          info,
+        ) => {
+          return info.mergeInfo.delegateToSchema({
+            schema: schemas(SchemaIdentifier.CONTENT_SERVICE),
+            operation: 'query',
+            fieldName: 'insuranceTerms',
+            args: {
+              contractType: contract.typeOfContract,
+              locale: args.locale,
+            },
+            context,
+            info,
+          })
+        },
+      },
+    }
+  })
+}
 
+const quotesExtension: CrossSchemaExtension = {
+  dependencies: [SchemaIdentifier.CONTENT_SERVICE, SchemaIdentifier.UNDERWRITER],
+  content: `
   extend type CompleteQuote {
     perils(locale: Locale!): [PerilV2!]!
     insurableLimits(locale: Locale!): [InsurableLimit!]!
@@ -30,13 +206,225 @@ export const crossSchemaExtensions = `
     insuranceTerms(locale: Locale!): [InsuranceTerm!]!
   }
 
+  ${quoteDetailsCrossSchemaExtensions}
+  ${quoteDisplayNameCrossSchemaExtensions}
+  `,
+  resolvers: (schemas) => ({
+    CompleteQuote: {
+      perils: {
+        fragment: `fragment CompleteQuoteCrossSchemaFragment on CompleteQuote { typeOfContract }`,
+        resolve: (quote: CompleteQuote, args: PerilsArgs, context, info) => {
+          return info.mergeInfo.delegateToSchema({
+            schema: schemas(SchemaIdentifier.CONTENT_SERVICE),
+            operation: 'query',
+            fieldName: 'perils',
+            args: {
+              contractType: quote.typeOfContract,
+              locale: args.locale,
+            },
+            context,
+            info,
+          })
+        },
+      },
+      insurableLimits: {
+        fragment: `fragment CompleteQuoteCrossSchemaFragment on CompleteQuote { typeOfContract }`,
+        resolve: (
+          quote: CompleteQuote,
+          args: InsurableLimitArgs,
+          context,
+          info,
+        ) => {
+          return info.mergeInfo.delegateToSchema({
+            schema: schemas(SchemaIdentifier.CONTENT_SERVICE),
+            operation: 'query',
+            fieldName: 'insurableLimits',
+            args: {
+              contractType: quote.typeOfContract,
+              locale: args.locale,
+            },
+            context,
+            info,
+          })
+        },
+      },
+      termsAndConditions: {
+        fragment: `fragment CompleteQuoteCrossSchemaFragment on CompleteQuote { typeOfContract }`,
+        resolve: (
+          quote: CompleteQuote,
+          args: TermsAndConditionsArgs,
+          context,
+          info,
+        ) => {
+          return info.mergeInfo.delegateToSchema({
+            schema: schemas(SchemaIdentifier.CONTENT_SERVICE),
+            operation: 'query',
+            fieldName: 'termsAndConditions',
+            args: {
+              contractType: quote.typeOfContract,
+              locale: args.locale,
+            },
+            context,
+            info,
+          })
+        },
+      },
+      insuranceTerms: {
+        fragment: `fragment CompleteQuoteCrossSchemaFragment on CompleteQuote { typeOfContract }`,
+        resolve: (
+          quote: CompleteQuote,
+          args: InsuranceTermsArgs,
+          context,
+          info,
+        ) => {
+          return info.mergeInfo.delegateToSchema({
+            schema: schemas(SchemaIdentifier.CONTENT_SERVICE),
+            operation: 'query',
+            fieldName: 'insuranceTerms',
+            args: {
+              contractType: quote.typeOfContract,
+              locale: args.locale,
+            },
+            context,
+            info,
+          })
+        },
+      },
+      ...quoteDetailsTable("CompleteQuote"),
+      ...quoteDisplayName("CompleteQuote")
+    },
+    BundledQuote: {
+      perils: {
+        fragment: `fragment CompleteQuoteCrossSchemaFragment on BundledQuote { typeOfContract }`,
+        resolve: (quote: BundledQuote, args: PerilsArgs, context, info) => {
+          return info.mergeInfo.delegateToSchema({
+            schema: schemas(SchemaIdentifier.CONTENT_SERVICE),
+            operation: 'query',
+            fieldName: 'perils',
+            args: {
+              contractType: quote.typeOfContract,
+              locale: args.locale,
+            },
+            context,
+            info,
+          })
+        },
+      },
+      insurableLimits: {
+        fragment: `fragment CompleteQuoteCrossSchemaFragment on BundledQuote { typeOfContract }`,
+        resolve: (
+          quote: BundledQuote,
+          args: InsurableLimitArgs,
+          context,
+          info,
+        ) => {
+          return info.mergeInfo.delegateToSchema({
+            schema: schemas(SchemaIdentifier.CONTENT_SERVICE),
+            operation: 'query',
+            fieldName: 'insurableLimits',
+            args: {
+              contractType: quote.typeOfContract,
+              locale: args.locale,
+            },
+            context,
+            info,
+          })
+        },
+      },
+      termsAndConditions: {
+        fragment: `fragment CompleteQuoteCrossSchemaFragment on BundledQuote { typeOfContract }`,
+        resolve: (
+          quote: BundledQuote,
+          args: TermsAndConditionsArgs,
+          context,
+          info,
+        ) => {
+          return info.mergeInfo.delegateToSchema({
+            schema: schemas(SchemaIdentifier.CONTENT_SERVICE),
+            operation: 'query',
+            fieldName: 'termsAndConditions',
+            args: {
+              contractType: quote.typeOfContract,
+              locale: args.locale,
+            },
+            context,
+            info,
+          })
+        },
+      },
+      insuranceTerms: {
+        fragment: `fragment CompleteQuoteCrossSchemaFragment on BundledQuote { typeOfContract }`,
+        resolve: (
+          quote: BundledQuote,
+          args: InsuranceTermsArgs,
+          context,
+          info,
+        ) => {
+          return info.mergeInfo.delegateToSchema({
+            schema: schemas(SchemaIdentifier.CONTENT_SERVICE),
+            operation: 'query',
+            fieldName: 'insuranceTerms',
+            args: {
+              contractType: quote.typeOfContract,
+              locale: args.locale,
+            },
+            context,
+            info,
+          })
+        },
+      },
+      ...quoteDetailsTable("BundledQuote"),
+      ...quoteDisplayName("BundledQuote")
+    }
+  })
+}
+
+const embarkExtension: CrossSchemaExtension = {
+  dependencies: [SchemaIdentifier.CONTENT_SERVICE, SchemaIdentifier.EMBARK],
+  content: `
   extend type EmbarkPreviousInsuranceProviderActionData {
     insuranceProviders: [InsuranceProvider!]!
   }
+  `,
+  resolvers: (schemas) => ({
+    EmbarkPreviousInsuranceProviderActionData: {
+      insuranceProviders: {
+        fragment: `fragment EmbarkPreviousInsuranceProviderActionDataCrossSchemaFragment on EmbarkPreviousInsuranceProviderActionData { providers }`,
+        resolve: (
+          actionData: EmbarkPreviousInsuranceProviderActionData,
+          _args: any,
+          context,
+          info,
+        ) => {
+          let locale;
+          const providers = actionData.providers ? actionData.providers.toLowerCase() : null
+          if (providers === null) {
+            locale = "en_SE"
+          } else if (providers === "swedish") {
+            locale = "en_SE"
+          } else if (providers === "norwegian") {
+            locale = "en_NO"
+          } else if (providers === "danish") {
+            locale = "en_DK"
+          } else {
+            throw Error(`No provider matches ${providers}`)
+          }
 
-  ${quoteDetailsCrossSchemaExtensions}
-  ${quoteDisplayNameCrossSchemaExtensions}
-`
+          return info.mergeInfo.delegateToSchema({
+            schema: schemas(SchemaIdentifier.CONTENT_SERVICE),
+            operation: 'query',
+            fieldName: 'insuranceProviders',
+            args: {
+              locale,
+            },
+            context,
+            info
+          })
+        }
+      }
+    }
+  })
+}
 
 const getCoveredIds = (category: KeyGearItemCategory) => {
   return {
@@ -201,333 +589,6 @@ enum Locale {
   en_NO = 'en_NO',
   da_DK = 'da_DK',
   en_DK = 'en_DK',
-}
-
-export const getCrossSchemaResolvers = (
-  graphcmsSchema: GraphQLSchema,
-  contentSchema: GraphQLSchema,
-): IResolvers => {
-  return {
-    KeyGearItem: {
-      covered: {
-        fragment: `fragment KeyGearCrossSchemaFragment on KeyGearItem { category }`,
-        resolve: (keyGearItem: KeyGearItem, _args, context, info) => {
-          return info.mergeInfo.delegateToSchema({
-            schema: graphcmsSchema,
-            operation: 'query',
-            fieldName: 'keyGearItemCoverages',
-            args: {
-              where: {
-                id_in: getCoveredIds(keyGearItem.category),
-              },
-            },
-            context,
-            info,
-          })
-        },
-      },
-      exceptions: {
-        fragment: `fragment KeyGearCrossSchemaFragment on KeyGearItem { category }`,
-        resolve: (keyGearItem: KeyGearItem, _args, context, info) => {
-          return info.mergeInfo.delegateToSchema({
-            schema: graphcmsSchema,
-            operation: 'query',
-            fieldName: 'keyGearItemCoverages',
-            args: {
-              where: {
-                id_in: getExceptionIds(keyGearItem.category),
-              },
-            },
-            context,
-            info,
-          })
-        },
-      },
-    },
-    Contract: {
-      perils: {
-        fragment: `fragment ContractCrossSchemaFragment on Contract { typeOfContract }`,
-        resolve: (contract: Contract, args: PerilsArgs, context, info) => {
-          return info.mergeInfo.delegateToSchema({
-            schema: contentSchema,
-            operation: 'query',
-            fieldName: 'perils',
-            args: {
-              contractType: contract.typeOfContract,
-              locale: args.locale,
-            },
-            context,
-            info,
-          })
-        },
-      },
-      insurableLimits: {
-        fragment: `fragment CompleteQuoteCrossSchemaFragment on Contract { typeOfContract }`,
-        resolve: (
-          contract: Contract,
-          args: InsurableLimitArgs,
-          context,
-          info,
-        ) => {
-          return info.mergeInfo.delegateToSchema({
-            schema: contentSchema,
-            operation: 'query',
-            fieldName: 'insurableLimits',
-            args: {
-              contractType: contract.typeOfContract,
-              locale: args.locale,
-            },
-            context,
-            info,
-          })
-        },
-      },
-      termsAndConditions: {
-        fragment: `fragment CompleteQuoteCrossSchemaFragment on Contract { typeOfContract }`,
-        resolve: (
-          contract: Contract,
-          args: TermsAndConditionsArgs,
-          context,
-          info,
-        ) => {
-          return info.mergeInfo.delegateToSchema({
-            schema: contentSchema,
-            operation: 'query',
-            fieldName: 'termsAndConditions',
-            args: {
-              contractType: contract.typeOfContract,
-              locale: args.locale,
-            },
-            context,
-            info,
-          })
-        },
-      },
-      insuranceTerms: {
-        fragment: `fragment CompleteQuoteCrossSchemaFragment on Contract { typeOfContract }`,
-        resolve: (
-          contract: Contract,
-          args: InsuranceTermsArgs,
-          context,
-          info,
-        ) => {
-          return info.mergeInfo.delegateToSchema({
-            schema: contentSchema,
-            operation: 'query',
-            fieldName: 'insuranceTerms',
-            args: {
-              contractType: contract.typeOfContract,
-              locale: args.locale,
-            },
-            context,
-            info,
-          })
-        },
-      },
-    },
-    CompleteQuote: {
-      perils: {
-        fragment: `fragment CompleteQuoteCrossSchemaFragment on CompleteQuote { typeOfContract }`,
-        resolve: (quote: CompleteQuote, args: PerilsArgs, context, info) => {
-          return info.mergeInfo.delegateToSchema({
-            schema: contentSchema,
-            operation: 'query',
-            fieldName: 'perils',
-            args: {
-              contractType: quote.typeOfContract,
-              locale: args.locale,
-            },
-            context,
-            info,
-          })
-        },
-      },
-      insurableLimits: {
-        fragment: `fragment CompleteQuoteCrossSchemaFragment on CompleteQuote { typeOfContract }`,
-        resolve: (
-          quote: CompleteQuote,
-          args: InsurableLimitArgs,
-          context,
-          info,
-        ) => {
-          return info.mergeInfo.delegateToSchema({
-            schema: contentSchema,
-            operation: 'query',
-            fieldName: 'insurableLimits',
-            args: {
-              contractType: quote.typeOfContract,
-              locale: args.locale,
-            },
-            context,
-            info,
-          })
-        },
-      },
-      termsAndConditions: {
-        fragment: `fragment CompleteQuoteCrossSchemaFragment on CompleteQuote { typeOfContract }`,
-        resolve: (
-          quote: CompleteQuote,
-          args: TermsAndConditionsArgs,
-          context,
-          info,
-        ) => {
-          return info.mergeInfo.delegateToSchema({
-            schema: contentSchema,
-            operation: 'query',
-            fieldName: 'termsAndConditions',
-            args: {
-              contractType: quote.typeOfContract,
-              locale: args.locale,
-            },
-            context,
-            info,
-          })
-        },
-      },
-      insuranceTerms: {
-        fragment: `fragment CompleteQuoteCrossSchemaFragment on CompleteQuote { typeOfContract }`,
-        resolve: (
-          quote: CompleteQuote,
-          args: InsuranceTermsArgs,
-          context,
-          info,
-        ) => {
-          return info.mergeInfo.delegateToSchema({
-            schema: contentSchema,
-            operation: 'query',
-            fieldName: 'insuranceTerms',
-            args: {
-              contractType: quote.typeOfContract,
-              locale: args.locale,
-            },
-            context,
-            info,
-          })
-        },
-      },
-      ...quoteDetailsTable("CompleteQuote"),
-      ...quoteDisplayName("CompleteQuote")
-    },
-    BundledQuote: {
-      perils: {
-        fragment: `fragment CompleteQuoteCrossSchemaFragment on BundledQuote { typeOfContract }`,
-        resolve: (quote: BundledQuote, args: PerilsArgs, context, info) => {
-          return info.mergeInfo.delegateToSchema({
-            schema: contentSchema,
-            operation: 'query',
-            fieldName: 'perils',
-            args: {
-              contractType: quote.typeOfContract,
-              locale: args.locale,
-            },
-            context,
-            info,
-          })
-        },
-      },
-      insurableLimits: {
-        fragment: `fragment CompleteQuoteCrossSchemaFragment on BundledQuote { typeOfContract }`,
-        resolve: (
-          quote: BundledQuote,
-          args: InsurableLimitArgs,
-          context,
-          info,
-        ) => {
-          return info.mergeInfo.delegateToSchema({
-            schema: contentSchema,
-            operation: 'query',
-            fieldName: 'insurableLimits',
-            args: {
-              contractType: quote.typeOfContract,
-              locale: args.locale,
-            },
-            context,
-            info,
-          })
-        },
-      },
-      termsAndConditions: {
-        fragment: `fragment CompleteQuoteCrossSchemaFragment on BundledQuote { typeOfContract }`,
-        resolve: (
-          quote: BundledQuote,
-          args: TermsAndConditionsArgs,
-          context,
-          info,
-        ) => {
-          return info.mergeInfo.delegateToSchema({
-            schema: contentSchema,
-            operation: 'query',
-            fieldName: 'termsAndConditions',
-            args: {
-              contractType: quote.typeOfContract,
-              locale: args.locale,
-            },
-            context,
-            info,
-          })
-        },
-      },
-      insuranceTerms: {
-        fragment: `fragment CompleteQuoteCrossSchemaFragment on BundledQuote { typeOfContract }`,
-        resolve: (
-          quote: BundledQuote,
-          args: InsuranceTermsArgs,
-          context,
-          info,
-        ) => {
-          return info.mergeInfo.delegateToSchema({
-            schema: contentSchema,
-            operation: 'query',
-            fieldName: 'insuranceTerms',
-            args: {
-              contractType: quote.typeOfContract,
-              locale: args.locale,
-            },
-            context,
-            info,
-          })
-        },
-      },
-      ...quoteDetailsTable("BundledQuote"),
-      ...quoteDisplayName("BundledQuote")
-    },
-    EmbarkPreviousInsuranceProviderActionData: {
-      insuranceProviders: {
-        fragment: `fragment EmbarkPreviousInsuranceProviderActionDataCrossSchemaFragment on EmbarkPreviousInsuranceProviderActionData { providers }`,
-        resolve: (
-          actionData: EmbarkPreviousInsuranceProviderActionData,
-          _args: any,
-          context,
-          info,
-        ) => {
-          let locale;
-          const providers = actionData.providers ? actionData.providers.toLowerCase() : null
-          if (providers === null) {
-            locale = "en_SE"
-          } else if (providers === "swedish") {
-            locale = "en_SE"
-          } else if (providers === "norwegian") {
-            locale = "en_NO"
-          } else if (providers === "danish") {
-            locale = "en_DK"
-          } else {
-            throw Error(`No provider matches ${providers}`)
-          }
-
-          return info.mergeInfo.delegateToSchema({
-            schema: contentSchema,
-            operation: 'query',
-            fieldName: 'insuranceProviders',
-            args: {
-              locale,
-            },
-            context,
-            info
-          })
-        }
-      }
-    }
-  }
 }
 
 interface EmbarkPreviousInsuranceProviderActionData {

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -207,13 +207,6 @@ const makeSchema = async () => {
       }
     ),
     introspectRemoteSchema(
-      "content-service",
-      {
-        url: process.env.CONTENT_SERVICE_GRAPHQL_ENDPOINT,
-        authorized: false
-      }
-    ),
-    introspectRemoteSchema(
       "embark",
       {
         url: process.env.EMBARK_GRAPHQL_ENDPOINT,


### PR DESCRIPTION
## Jira ticket: [MX-71]

### What
- Introduces a new environment variable called `GRAPHQL_SCHEMA_INTROSPECTION_MODE` that defines how the upstream remote schema stitching should work.
- One of the modes, called `fault-tolerant`, enables fetching the schemas you have access to, but not failing if any of them are inaccessible
- Cross-schema extensions are resolved dynamically based on which upstreams were successful

[MX-71]: https://hedvig.atlassian.net/browse/MX-71