### PR TITLE
Apply the gql tag to schema extensions, getting early schema compilation and syntax highlighting

### DIFF
--- a/src/resolvers/cross-schema/campaignDisplayValue.ts
+++ b/src/resolvers/cross-schema/campaignDisplayValue.ts
@@ -1,6 +1,7 @@
+import gql from 'graphql-tag'
 import { IResolvers } from 'graphql-tools'
 
-export const crossSchemaExtensions = `
+export const crossSchemaExtensions = gql`
     extend type Campaign {
         displayValue(locale: Locale!): String
     }

--- a/src/resolvers/cross-schema/quoteFaqs.ts
+++ b/src/resolvers/cross-schema/quoteFaqs.ts
@@ -1,8 +1,9 @@
+import gql from "graphql-tag"
 import { CrossSchemaExtension, SchemaIdentifier } from "./index"
 
 export const createQuoteFaqsExtension = (): CrossSchemaExtension => ({
     dependencies: [SchemaIdentifier.GRAPH_CMS, SchemaIdentifier.UNDERWRITER],
-    content: `
+    content: gql`
         extend type QuoteBundle {
             frequentlyAskedQuestions(locale: Locale!): [Faq!]!
         }

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -269,10 +269,10 @@ const makeSchema = async (): Promise<SchemaIntrospectionResult> => {
   logger.info('Merging schemas')
   const schema = mergeSchemas({
     schemas: [
-      ...remoteSchemas.map(s => s?.schema),
+      ...remoteSchemas.filter(s => s?.schema).map(s => s.schema!!),
       localSchema,
-      crossSchemaExtensions.extension,
-    ].filter(Boolean) as GraphQLSchema[],
+      ...crossSchemaExtensions.extensions,
+    ],
     resolvers: crossSchemaExtensions.resolvers,
   })
 


### PR DESCRIPTION
# Jira Issue: []

## What?
- Compile GraphQL schema extensions using `gql` to verify their syntax and get highlighting

## Why?
- Types are sometimes better than strings? 🤷 

## Optional checklist
- [ ] Unit tests written
- [x] Tested locally
- [x] Codescouted
