### PR TITLE
send in 'initiatedFrom: SELF_CHANGE' for address change quotes

### DIFF
--- a/src/api/upstreams/underwriter.ts
+++ b/src/api/upstreams/underwriter.ts
@@ -11,6 +11,7 @@ export interface CreateQuoteDto {
   ssn: string
   birthDate: string
   startDate: string
+  initiatedFrom: QuoteInitiatedFromDto,
   swedishApartmentData?: {
     street: string
     zipCode: string
@@ -66,6 +67,17 @@ export interface CreateQuoteDto {
     student: boolean
   }
 }
+
+export enum QuoteInitiatedFromDto {
+  Rapio = 'RAPIO',
+  WebOnboarding = 'WEBONBOARDING',
+  App = 'APP',
+  Ios = 'IOS',
+  Android = 'ANDROID',
+  Hope = 'HOPE',
+  SelfChange = 'SELF_CHANGE'
+}
+
 
 export type QuoteCreationResult =
   | QuoteCreationSuccessDto

--- a/src/resolvers/__snapshots__/addressChange.test.ts.snap
+++ b/src/resolvers/__snapshots__/addressChange.test.ts.snap
@@ -14,6 +14,7 @@ Array [
         "zipCode": "12345",
       },
       "firstName": "Test",
+      "initiatedFrom": "SELF_CHANGE",
       "lastName": "Testsson",
       "memberId": "123",
       "ssn": "201212121212",
@@ -30,6 +31,7 @@ Array [
         "zipCode": "12345",
       },
       "firstName": "Test",
+      "initiatedFrom": "SELF_CHANGE",
       "lastName": "Testsson",
       "memberId": "123",
       "ssn": "201212121212",
@@ -46,6 +48,7 @@ Array [
         "zipCode": "12345",
       },
       "firstName": "Test",
+      "initiatedFrom": "SELF_CHANGE",
       "lastName": "Testsson",
       "memberId": "123",
       "ssn": "201212121212",
@@ -61,6 +64,7 @@ Array [
     Object {
       "birthDate": "1991-07-27",
       "firstName": "Test",
+      "initiatedFrom": "SELF_CHANGE",
       "lastName": "Testsson",
       "memberId": "123",
       "norwegianHomeContentsData": Object {
@@ -79,6 +83,7 @@ Array [
     Object {
       "birthDate": "1991-07-27",
       "firstName": "Test",
+      "initiatedFrom": "SELF_CHANGE",
       "lastName": "Testsson",
       "memberId": "123",
       "norwegianTravelData": Object {
@@ -98,6 +103,7 @@ Array [
     Object {
       "birthDate": "1991-07-27",
       "firstName": "Test",
+      "initiatedFrom": "SELF_CHANGE",
       "lastName": "Testsson",
       "memberId": "123",
       "ssn": "201212121212",
@@ -120,6 +126,7 @@ Array [
     Object {
       "birthDate": "1991-07-27",
       "firstName": "Test",
+      "initiatedFrom": "SELF_CHANGE",
       "lastName": "Testsson",
       "memberId": "123",
       "ssn": "201212121212",
@@ -142,6 +149,7 @@ Array [
     Object {
       "birthDate": "1991-07-27",
       "firstName": "Test",
+      "initiatedFrom": "SELF_CHANGE",
       "lastName": "Testsson",
       "memberId": "123",
       "ssn": "201212121212",
@@ -164,6 +172,7 @@ Array [
     Object {
       "birthDate": "1991-07-27",
       "firstName": "Test",
+      "initiatedFrom": "SELF_CHANGE",
       "lastName": "Testsson",
       "memberId": "123",
       "ssn": "201212121212",
@@ -186,6 +195,7 @@ Array [
     Object {
       "birthDate": "1991-07-27",
       "firstName": "Test",
+      "initiatedFrom": "SELF_CHANGE",
       "lastName": "Testsson",
       "memberId": "123",
       "ssn": "201212121212",

--- a/src/resolvers/addressChange.ts
+++ b/src/resolvers/addressChange.ts
@@ -1,5 +1,5 @@
 import { MemberDto } from './../api/upstreams/memberService';
-import { QuoteCreationResult, CreateQuoteDto } from './../api/upstreams/underwriter';
+import { QuoteCreationResult, CreateQuoteDto, QuoteInitiatedFromDto } from './../api/upstreams/underwriter';
 import {
   MutationToCreateAddressChangeQuotesResolver,
   AddressChangeQuoteResult,
@@ -52,6 +52,7 @@ const convertAddressChangeToSelfChangeBody = (
     ssn: member.ssn,
     birthDate: member.birthDate,
     startDate: input.startDate,
+    initiatedFrom: QuoteInitiatedFromDto.SelfChange
   }
 
   switch (marketInfo.market) {


### PR DESCRIPTION
# Jira Issue: [MX-21]

## What?
- Correctly inject `"inidiatedFrom": "SELF_CHANGE"` when creating quotes from the moving flow mutation

## Why?
- This is both needed for getting the correct signing method, but also for traceability

## Optional checklist
- [x] Unit tests written
- [x] Tested locally
- [x] Codescouted


[MX-21]: https://hedvig.atlassian.net/browse/MX-21