### PR TITLE
MX-162: wire the Trial model into 'fake contracts', to make them compatible with existing apps

### DIFF
--- a/src/api/upstreams/productPricing.ts
+++ b/src/api/upstreams/productPricing.ts
@@ -17,6 +17,10 @@ export interface ProductPricingClient {
    * Get the data related to whether the 'self change' functionality of contracts is available.
    */
   getSelfChangeEligibility(): Promise<SelfChangeEligibilityDto>
+  /**
+   * Get the "trial insurances" for this member, if there are any.
+   */
+  getTrials(): Promise<TrialDto[]>
 }
 
 export interface ContractMarketInfoDto {
@@ -158,6 +162,26 @@ export interface ExtraBuildingDto {
   hasWaterConnected: boolean
 }
 
+export interface TrialDto {
+  id: string
+  memberId: string
+  fromDate: string
+  toDate: string
+  type: string
+  partner: string
+  address: TrialAddressDto
+  createdAt: string
+}
+
+export interface TrialAddressDto {
+  street: string
+  city: string
+  zipCode: string
+  livingSpace?: number
+  apartmentNo?: string
+  floor?: string
+}
+
 export const createProductPricingClient = (
   client: HttpClient,
 ): ProductPricingClient => {
@@ -176,6 +200,10 @@ export const createProductPricingClient = (
     },
     getSelfChangeEligibility: async () => {
       const res = await client.get('/contracts/selfChange/eligibility')
+      return res.json()
+    },
+    getTrials: async () => {
+      const res = await client.get('/trial')
       return res.json()
     },
   }

--- a/src/api/upstreams/productPricing.ts
+++ b/src/api/upstreams/productPricing.ts
@@ -168,9 +168,11 @@ export interface TrialDto {
   fromDate: string
   toDate: string
   type: string
+  status: string
   partner: string
   address: TrialAddressDto
   createdAt: string
+  certificateUrl?: string
 }
 
 export interface TrialAddressDto {

--- a/src/resolvers/addressChange.test.ts
+++ b/src/resolvers/addressChange.test.ts
@@ -11,13 +11,13 @@ import { startApolloTesting } from '../test-utils/test-server'
 
 const { mutate, upstream } = startApolloTesting()
 
-upstream.memberService.getSelfMember = () => Promise.resolve(member)
-
 const createQuote = jest.fn().mockResolvedValue('qid1')
-upstream.underwriter.createQuote = createQuote
 beforeEach(() => {
   createQuote.mockClear()
   createQuote.mockResolvedValue('qid1')
+
+  upstream.memberService.getSelfMember = () => Promise.resolve(member)
+  upstream.underwriter.createQuote = createQuote
 })
 
 // Tests

--- a/src/resolvers/contracts.test.ts
+++ b/src/resolvers/contracts.test.ts
@@ -438,6 +438,7 @@ describe('Query.contracts', () => {
         fromDate: '2021-06-01',
         toDate: '2021-07-01',
         type: 'SE_APARTMENT_BRF',
+        status: 'TERMINATED_IN_FUTURE',
         partner: 'AVY',
         address: {
           street: 'Fakestreet 123',
@@ -445,7 +446,8 @@ describe('Query.contracts', () => {
           city: 'Atlantis',
           livingSpace: 44
         },
-        createdAt: '2021-05-31T10:00:00Z'
+        createdAt: '2021-05-31T10:00:00Z',
+        certificateUrl: 'https://hedvig.com/cert',
       }
     ])
     const fakeContract: Contract = {
@@ -453,8 +455,8 @@ describe('Query.contracts', () => {
       holderMember: 'mid1',
       typeOfContract: TypeOfContract.SE_APARTMENT_BRF,
       status: {
-        __typename: 'ActiveStatus',
-        pastInception: '2021-06-01'
+        __typename: 'TerminatedInFutureStatus',
+        futureTermination: '2021-07-01'
       } as ContractStatus,
       displayName: 'CONTRACT_DISPLAY_NAME_SE_APARTMENT_BRF',
       createdAt: '2021-05-31T10:00:00Z',
@@ -467,7 +469,7 @@ describe('Query.contracts', () => {
           amount: '0',
           currency: 'SEK'
         },
-        certificateUrl: 'http://TODO',
+        certificateUrl: 'https://hedvig.com/cert',
         status: AgreementStatus.ACTIVE,
         address: {
           street: 'Fakestreet 123',

--- a/src/resolvers/contracts.test.ts
+++ b/src/resolvers/contracts.test.ts
@@ -13,7 +13,9 @@ import {
   TerminatedStatus,
   ActiveInFutureAndTerminatedInFutureStatus,
   ContractBundle,
-  ExtraBuildingType
+  ExtraBuildingType,
+  ContractStatus,
+  Agreement
 } from './../typings/generated-graphql-types'
 import {
   AgreementStatusDto,
@@ -426,6 +428,62 @@ describe('Query.contracts', () => {
       { ...norwegianTravelOutput, id: 'cid-travel' }
     ])
   })
+
+  it('Trial is turned into a fake swedish apartment contract', async () => {
+    context.upstream.productPricing.getMemberContracts = () => Promise.resolve([])
+    context.upstream.productPricing.getTrials = () => Promise.resolve([
+      {
+        id: 'tid1',
+        memberId: 'mid1',
+        fromDate: '2021-06-01',
+        toDate: '2021-07-01',
+        type: 'SE_APARTMENT_BRF',
+        partner: 'AVY',
+        address: {
+          street: 'Fakestreet 123',
+          zipCode: '12345',
+          city: 'Atlantis',
+          livingSpace: 44
+        },
+        createdAt: '2021-05-31T10:00:00Z'
+      }
+    ])
+    const fakeContract: Contract = {
+      id: 'fakecontract:tid1',
+      holderMember: 'mid1',
+      typeOfContract: TypeOfContract.SE_APARTMENT_BRF,
+      status: {
+        __typename: 'ActiveStatus',
+        pastInception: '2021-06-01'
+      } as ContractStatus,
+      displayName: 'CONTRACT_DISPLAY_NAME_SE_APARTMENT_BRF',
+      createdAt: '2021-05-31T10:00:00Z',
+      currentAgreement: {
+        __typename: 'SwedishApartmentAgreement',
+        id: 'fakeagreement:tid1',
+        activeFrom: '2021-06-01',
+        activeTo: '2021-07-01',
+        premium: {
+          amount: '0',
+          currency: 'SEK'
+        },
+        certificateUrl: 'http://TODO',
+        status: AgreementStatus.ACTIVE,
+        address: {
+          street: 'Fakestreet 123',
+          postalCode: '12345'
+        },
+        numberCoInsured: 0,
+        squareMeters: 44,
+        type: SwedishApartmentLineOfBusiness.BRF,
+      } as Agreement
+    }
+
+    const result = await contracts(undefined, {}, context, info)
+
+    expect(result).toMatchObject<Contract[]>([fakeContract])
+  })
+
 })
 
 describe('Query.hasContract', () => {
@@ -458,6 +516,7 @@ const context: Context = ({
   upstream: {
     productPricing: {
       getMemberContracts: () => Promise.resolve([]),
+      getTrials: () => Promise.resolve([]),
       getSelfChangeEligibility: () => Promise.resolve(
         { blockers: [ "FAKE" ] }
       )

--- a/src/resolvers/contracts.ts
+++ b/src/resolvers/contracts.ts
@@ -338,33 +338,24 @@ const transformTrialToFakeContract = (trial: TrialDto, strings: LocalizedStrings
     'TERMINATED_TODAY': AgreementStatus.ACTIVE,
     'TERMINATED': AgreementStatus.TERMINATED,
   }
-  let status: Typenamed<ContractStatus, PossibleContractStatusTypeNames>
-  if (trial.status === 'ACTIVE_IN_FUTURE_AND_TERMINATED_IN_FUTURE') {
-    status = {
-      __typename: 'ActiveInFutureAndTerminatedInFutureStatus',
-      futureInception: trial.fromDate,
-      futureTermination: trial.toDate
-    }
-  } else if (trial.status === 'TERMINATED_IN_FUTURE') {
-    status = {
-      __typename: 'TerminatedInFutureStatus',
-      futureTermination: trial.toDate
-    }
-  } else if (trial.status === 'TERMINATED_TODAY') {
-    status = {
-      __typename: 'TerminatedTodayStatus',
-      today: trial.toDate
-    }
-  } else if (trial.status === 'TERMINATED') {
-    status = {
-      __typename: 'TerminatedStatus',
-      termination: trial.toDate
-    }
-  } else {
-    status = {
-      __typename: 'ActiveStatus',
-      pastInception: trial.fromDate,
-    }
+  const contractStatusTransformation: Record<string, Typenamed<ContractStatus, PossibleContractStatusTypeNames>> = {
+    'ACTIVE_IN_FUTURE_AND_TERMINATED_IN_FUTURE': {
+        __typename: 'ActiveInFutureAndTerminatedInFutureStatus',
+        futureInception: trial.fromDate,
+        futureTermination: trial.toDate
+      },
+    'TERMINATED_IN_FUTURE': {
+        __typename: 'TerminatedInFutureStatus',
+        futureTermination: trial.toDate
+      },
+    'TERMINATED_TODAY': {
+        __typename: 'TerminatedTodayStatus',
+        today: trial.toDate
+      },
+    'TERMINATED': {
+        __typename: 'TerminatedStatus',
+        termination: trial.toDate
+      }
   }
 
   const typeOfContract = typeTransformation[trial.type]
@@ -372,7 +363,7 @@ const transformTrialToFakeContract = (trial: TrialDto, strings: LocalizedStrings
     id: `fakecontract:${trial.id}`,
     holderMember: trial.memberId,
     typeOfContract,
-    status,
+    status: contractStatusTransformation[trial.status],
     displayName: strings(`CONTRACT_DISPLAY_NAME_${typeOfContract}`),
     createdAt: trial.createdAt,
     currentAgreement: {

--- a/src/test-utils/test-server.ts
+++ b/src/test-utils/test-server.ts
@@ -13,12 +13,13 @@ const typeDefs = gql(
   readFileSync(resolve(__dirname, '../schema.graphqls'), 'utf8'),
 )
 
-const upstream: Upstream = {
+const fakeUpstream = (): Upstream => ({
   productPricing: {
     getContract: () => Promise.reject("getContract Not implemented"),
     getMemberContracts: () => Promise.reject("getMemberContracts Not implemented"),
     getContractMarketInfo: () => Promise.reject("getContractMarketInfo Not implemented"),
-    getSelfChangeEligibility: () => Promise.reject("getSelfChangeEligibility Not implemented")
+    getSelfChangeEligibility: () => Promise.reject("getSelfChangeEligibility Not implemented"),
+    getTrials: () => Promise.reject("getTrials Not implemented"),
   },
   underwriter: {
     createQuote: () => Promise.reject("createQuote Not implemented"),
@@ -26,7 +27,9 @@ const upstream: Upstream = {
   memberService: {
     getSelfMember: () => Promise.reject("getSelfMember Not implemented")
   }
-}
+})
+
+const upstream = fakeUpstream()
 
 const context: Context = {
     getToken: () => 'test-token',
@@ -63,6 +66,11 @@ export interface TestingContext {
 }
 
 export const startApolloTesting = (): TestingContext => {
+  afterEach(() => {
+    // Reset upstream mocks between tests
+    Object.assign(upstream, fakeUpstream())
+  })
+
   const server = new ApolloServer({
     schema: localSchema,
     context: context


### PR DESCRIPTION
# Jira Issue: [MX-162]

## What?
- Wire the new `Trial` model onto the `Contract` queries inside Giraffe, turning them into a fake "Swedish apartment contract"
- Draft because the details are definitely not done here

## Why?
- These trials match something Avy members have been given as a "one month free" concept
- To avoid squeezing all of this into C&A, we built a new decoupled concept called 'trials'
- In order for it to be backwards compatible with the apps, we had to retrofit it onto the contracts model at some point

## Optional checklist
- [x] Unit tests written
- [x] Tested locally
- [x] Codescouted

## Screenshots
![image](https://user-images.githubusercontent.com/2649932/122552308-6ec2be80-d036-11eb-9a5c-7b2a587c95fa.png)


[MX-162]: https://hedvig.atlassian.net/browse/MX-162