### PR TITLE
Add extension that signs or approves quotes

### DIFF
--- a/src/resolvers/cross-schema/index.ts
+++ b/src/resolvers/cross-schema/index.ts
@@ -12,6 +12,7 @@ import { createQuoteFaqsExtension } from "./quoteFaqs"
 import { createQuoteBundleAppConfigurationExtension } from './quoteBundleAppConfiguration';
 import { createQuoteBundleDisplayNameExtension } from './quoteBundleDisplayName';
 import { createQuoteBundleOrderedQuotesExtension } from './quoteBundleOrderedQuotesExtension';
+import { createSignOrApproveQuotesExtension } from './signOrApproveQuotes';
 
 export enum SchemaIdentifier {
   GRAPH_CMS = "graph-cms",
@@ -46,7 +47,8 @@ export const getCrossSchemaExtensions = (
     createQuoteFaqsExtension(),
     createQuoteBundleAppConfigurationExtension(),
     createQuoteBundleDisplayNameExtension(),
-    createQuoteBundleOrderedQuotesExtension()
+    createQuoteBundleOrderedQuotesExtension(),
+    createSignOrApproveQuotesExtension()
   ]
 
   const applicable = allExtensions.filter(extension => {

--- a/src/resolvers/cross-schema/signOrApproveQuotes.ts
+++ b/src/resolvers/cross-schema/signOrApproveQuotes.ts
@@ -1,0 +1,102 @@
+import { gql } from 'apollo-server-koa';
+import {  ExtractField } from "graphql-tools"
+import { SchemaIdentifier, CrossSchemaExtension } from "./index"
+
+export const createSignOrApproveQuotesExtension = (): CrossSchemaExtension => ({
+  dependencies: [SchemaIdentifier.UNDERWRITER],
+  content: gql`
+      type SignOrApprove {
+        signResponse: StartSignResponse
+        approved: Boolean
+      }
+
+      extend type Mutation {
+          signOrApproveQuotes(quoteIds: [ID!]!): SignOrApprove
+      }
+    `,
+  resolvers: (schemas) => ({
+    Mutation: {
+      signOrApproveQuotes: {
+        resolve: (
+          _,
+          args: {
+            quoteIds: string[]
+          },
+          context,
+          info
+        ) => {
+          const underwriterSchema = schemas(SchemaIdentifier.UNDERWRITER)
+
+          return info.mergeInfo.delegateToSchema({
+            schema: underwriterSchema,
+            operation: 'query',
+            fieldName: 'signMethodForQuotes',
+            args: {
+              input: args.quoteIds,
+            },
+            context,
+            info: info,
+            transforms: [
+              {
+                transformRequest: (originalRequest: any) => {
+                  return { ...originalRequest, document: gql`
+                    query ($input: [ID!]!) {
+                      signMethodForQuotes(input: $input)
+                    }
+                  ` }
+                }
+              }
+            ]
+          }).then((signMethod: string) => {
+            console.log(signMethod)
+            switch (signMethod) {
+              case "APPROVE_ONLY":
+                return info.mergeInfo.delegateToSchema({
+                  schema: underwriterSchema,
+                  operation: 'mutation',
+                  fieldName: 'approveQuotes',
+                  args: {
+                    quoteIds: args.quoteIds,
+                  },
+                  context,
+                  info,
+                  transforms: [
+                    new ExtractField({
+                      from: ['approveQuotes', 'approved'],
+                      to: ['approveQuotes']
+                    })
+                  ]
+                }).then((approved: boolean) => ({
+                  signResponse: null,
+                  approved
+                }))
+              default:
+                return info.mergeInfo.delegateToSchema({
+                  schema: underwriterSchema,
+                  operation: 'mutation',
+                  fieldName: 'signQuotes',
+                  args: {
+                    input: {
+                      quoteIds: args.quoteIds,
+                    }
+                  },
+                  context,
+                  info,
+                  transforms: [
+                    new ExtractField({
+                      from: ['signQuotes', 'signResponse'],
+                      to: ['signQuotes']
+                    })
+                  ]
+                }).then((startSignResponse: any) => ({
+                  signResponse: startSignResponse,
+                  approved: null
+                }))
+            }
+          })
+
+        }
+      }
+    }
+  })
+})

--- a/src/resolvers/cross-schema/signOrApproveQuotes.ts
+++ b/src/resolvers/cross-schema/signOrApproveQuotes.ts
@@ -1,5 +1,5 @@
 import { gql } from 'apollo-server-koa';
-import {  ExtractField } from "graphql-tools"
+import { ExtractField } from "graphql-tools"
 import { SchemaIdentifier, CrossSchemaExtension } from "./index"
 
 export const createSignOrApproveQuotesExtension = (): CrossSchemaExtension => ({
@@ -39,7 +39,8 @@ export const createSignOrApproveQuotesExtension = (): CrossSchemaExtension => ({
             transforms: [
               {
                 transformRequest: (originalRequest: any) => {
-                  return { ...originalRequest, document: gql`
+                  return {
+                    ...originalRequest, document: gql`
                     query ($input: [ID!]!) {
                       signMethodForQuotes(input: $input)
                     }
@@ -48,7 +49,6 @@ export const createSignOrApproveQuotesExtension = (): CrossSchemaExtension => ({
               }
             ]
           }).then((signMethod: string) => {
-            console.log(signMethod)
             switch (signMethod) {
               case "APPROVE_ONLY":
                 return info.mergeInfo.delegateToSchema({

--- a/src/resolvers/cross-schema/signOrApproveQuotes.ts
+++ b/src/resolvers/cross-schema/signOrApproveQuotes.ts
@@ -5,13 +5,18 @@ import { SchemaIdentifier, CrossSchemaExtension } from "./index"
 export const createSignOrApproveQuotesExtension = (): CrossSchemaExtension => ({
   dependencies: [SchemaIdentifier.UNDERWRITER],
   content: gql`
-      type SignOrApprove {
-        signResponse: StartSignResponse
-        approved: Boolean
+      union SignOrApprove = SignQuoteResponse | ApproveQuoteResponse
+
+      type SignQuoteResponse {
+        signResponse: StartSignResponse!
+      }
+
+      type ApproveQuoteResponse {
+        approved: Boolean!
       }
 
       extend type Mutation {
-          signOrApproveQuotes(quoteIds: [ID!]!): SignOrApprove
+          signOrApproveQuotes(quoteIds: [ID!]!): SignOrApprove!
       }
     `,
   resolvers: (schemas) => ({
@@ -67,7 +72,7 @@ export const createSignOrApproveQuotesExtension = (): CrossSchemaExtension => ({
                     })
                   ]
                 }).then((approved: boolean) => ({
-                  signResponse: null,
+                  __typename: "ApproveQuoteResponse",
                   approved
                 }))
               default:
@@ -89,8 +94,8 @@ export const createSignOrApproveQuotesExtension = (): CrossSchemaExtension => ({
                     })
                   ]
                 }).then((startSignResponse: any) => ({
-                  signResponse: startSignResponse,
-                  approved: null
+                  __typename: "SignQuoteResponse",
+                  signResponse: startSignResponse
                 }))
             }
           })


### PR DESCRIPTION
# Jira Issue: [APP-557]

## What?

> Adds a mutation that approves a quote if its signMethod is "APPROVE_ONLY" else forwards to `signQuotes`

## Why?

> So that the apps don't need to know about the difference between approval and signing in the offer screen

## Optional checklist
- [ ] Unit tests written
- [x] Tested locally
- [ ] Codescouted


[APP-557]: https://hedvig.atlassian.net/browse/APP-557