### PR TITLE
MX-117: Sort contracts in natural order, not only by moving home content to top

### DIFF
--- a/src/resolvers/contracts.test.ts
+++ b/src/resolvers/contracts.test.ts
@@ -119,16 +119,16 @@ describe('Query.activeContractBundles', () => {
       ...danishHomeContentInput,
       id: 'cid1',
     }
-    const travel = {
-      ...danishTravelInput,
-      id: 'cid2',
-    }
     const accident = {
       ...danishAccidentInput,
+      id: 'cid2',
+    }
+    const travel = {
+      ...danishTravelInput,
       id: 'cid3',
     }
     context.upstream.productPricing.getMemberContracts = () =>
-      Promise.resolve([homeContent, travel, accident])
+      Promise.resolve([homeContent, accident, travel])
 
     const result = await activeContractBundles(undefined, {}, context, info)
 
@@ -141,11 +141,11 @@ describe('Query.activeContractBundles', () => {
             id: 'cid1',
           },
           {
-            ...danishTravelOutput,
+            ...danishAccidentOutput,
             id: 'cid2',
           },
           {
-            ...danishAccidentOutput,
+            ...danishTravelOutput,
             id: 'cid3',
           },
         ],
@@ -201,22 +201,27 @@ describe('Query.activeContractBundles', () => {
     expect(result[0].id).toBe('bundle-a,z')
   })
 
-  it('HomeContent contracts are moved to the top', async () => {
+  it('Contracts are sorted in natural order', async () => {
     const travel = {
-      ...norwegianTravelInput,
-      id: 'cid1',
+      ...danishTravelInput,
+      id: 'cid-travel',
     }
     const homeContent = {
-      ...norwegianHomeContentInput,
-      id: 'cid2',
+      ...danishHomeContentInput,
+      id: 'cid-hc',
+    }
+    const accident = {
+      ...danishAccidentInput,
+      id: 'cid-accident',
     }
     context.upstream.productPricing.getMemberContracts = () =>
-      Promise.resolve([homeContent, travel])
+      Promise.resolve([travel, homeContent, accident])
 
     const result = await activeContractBundles(undefined, {}, context, info)
 
-    expect(result[0].contracts[0].id).toBe('cid2')
-    expect(result[0].contracts[1].id).toBe('cid1')
+    expect(result[0].contracts[0].id).toBe('cid-hc')
+    expect(result[0].contracts[1].id).toBe('cid-accident')
+    expect(result[0].contracts[2].id).toBe('cid-travel')
   })
 
   it('Moving flow story is visible if there are no blockers', async () => {
@@ -415,17 +420,19 @@ describe('Query.contracts', () => {
     expect(result).toMatchObject<Contract[]>([danishAccidentOutput])
   })
 
-  it('HomeContent contracts are moved to the top', async () => {
+  it('Contracts are sorted in natural order', async () => {
     context.upstream.productPricing.getMemberContracts = () => Promise.resolve([
-      { ...norwegianTravelInput, id: 'cid-travel' },
-      { ...norwegianHomeContentInput, id: 'cid-hc' }
+      { ...danishTravelInput, id: 'cid-travel' },
+      { ...danishHomeContentInput, id: 'cid-hc' },
+      { ...danishAccidentInput, id: 'cid-accident' }
     ])
 
     const result = await contracts(undefined, {}, context, info)
 
     expect(result).toMatchObject<Contract[]>([
-      { ...norwegianHomeContentOutput, id: 'cid-hc' },
-      { ...norwegianTravelOutput, id: 'cid-travel' }
+      { ...danishHomeContentOutput, id: 'cid-hc' },
+      { ...danishAccidentOutput, id: 'cid-accident' },
+      { ...danishTravelOutput, id: 'cid-travel' },
     ])
   })
 

--- a/src/resolvers/contracts.ts
+++ b/src/resolvers/contracts.ts
@@ -67,7 +67,7 @@ export const contracts: QueryToContractsResolver = async (
     upstream.productPricing.getMemberContracts(),
     upstream.productPricing.getTrials()
   ])
-  moveHomeContentsToTop(contracts)
+  sortContractsInNaturalOrder(contracts)
   const mappedContracts = contracts.map((c) => transformContract(c, strings))
   const fakeContracts = trials.map((t) => transformTrialToFakeContract(t, strings))
   return mappedContracts.concat(fakeContracts)
@@ -90,7 +90,7 @@ export const bundleContracts = (
   contracts: ContractDto[],
   addressChangeAngelStoryId?: string,
 ): ContractBundle[] => {
-    moveHomeContentsToTop(contracts)
+    sortContractsInNaturalOrder(contracts)
 
     const norwegianBundle = [] as ContractDto[]
     const danishBundle = [] as ContractDto[]
@@ -315,12 +315,13 @@ const transformAgreement = (
   }
 }
 
-const moveHomeContentsToTop = (contracts: ContractDto[]) => {
-  contracts.sort((c1, c2) => {
-    if (c1.typeOfContract.includes('HOME_CONTENT')) return -1
-    if (c2.typeOfContract.includes('HOME_CONTENT')) return 1
-    return 0
-  })
+const sortContractsInNaturalOrder = (contracts: ContractDto[]) => {
+  const priority = (contract: ContractDto): number => 
+    contract.typeOfContract.includes('HOME_CONTENT') ? 0
+    : contract.typeOfContract.includes('ACCIDENT') ? 1
+    : 2
+
+  contracts.sort((c1, c2) => priority(c1) - priority(c2))
 }
 
 const transformTrialToFakeContract = (trial: TrialDto, strings: LocalizedStrings): Contract => {

--- a/src/resolvers/cross-schema/quoteBundleOrderedQuotesExtension.ts
+++ b/src/resolvers/cross-schema/quoteBundleOrderedQuotesExtension.ts
@@ -54,11 +54,13 @@ export const createQuoteBundleOrderedQuotesExtension = (): CrossSchemaExtension 
               }
             ]
           }).then((quoteBundle: QuoteBundle) => {
+            const priority = (quote: Quote): number =>
+              quote.typeOfContract.includes('HOME_CONTENT') ? 0
+              : quote.typeOfContract.includes('ACCIDENT') ? 1
+              : 2
             const sortedBundle = {
               ...quoteBundle, quotes: quoteBundle.quotes.sort((quoteA, quoteB) => {
-                if (quoteA.typeOfContract.includes('HOME_CONTENT')) return -1
-                if (quoteB.typeOfContract.includes('HOME_CONTENT')) return 1
-                return 0
+                return priority(quoteA) - priority(quoteB)
               })
             }
 


### PR DESCRIPTION
# Jira Issue: [MX-117]

## What?
- Sort all kinds of contracts in natural order, not only home content

## Why?
- That's what's in the ticket :D 

## Optional checklist
- [x] Unit tests written
- [ ] Tested locally
- [x] Codescouted


[MX-117]: https://hedvig.atlassian.net/browse/MX-117