### PR TITLE
Avoid GraphQL errors being triple-logged in Giraffe

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,6 @@ import { makeSchema } from './schema'
 import { factory } from './utils/log'
 
 import * as Sentry from '@sentry/node'
-import { getInnerErrorsFromCombinedError } from './utils/graphql-error'
 Sentry.init({
   dsn: config.SENTRY_DSN,
   enabled: Boolean(config.SENTRY_DSN),
@@ -30,18 +29,14 @@ const logger = factory.getLogger('index')
 
 const handleError = (error: GraphQLError): void => {
   logger.error(
-    'Uncaught error in GraphQL. Original error: ',
+    'Uncaught error in GraphQL:',
     error.originalError,
-  )
-
-  getInnerErrorsFromCombinedError(error).forEach((err) =>
-    logger.error('Inner error: ', err),
   )
 }
 
 logger.info('Starting Giraffe 🦒')
-logger.info('Making schema')
 
+logger.info('Making schema')
 makeSchema()
   .then(({ schema, graphCMSSchema }) => {
     logger.info('Schema initialized')

--- a/src/middlewares/sentry.ts
+++ b/src/middlewares/sentry.ts
@@ -1,9 +1,6 @@
 import * as Sentry from '@sentry/node'
 import { IMiddleware } from 'graphql-middleware'
 import { getInnerErrorsFromCombinedError } from '../utils/graphql-error'
-import { factory } from '../utils/log'
-
-const logger = factory.getLogger('SentryMiddleware')
 
 export const sentryMiddleware: IMiddleware = async (
   resolve,
@@ -24,7 +21,6 @@ export const sentryMiddleware: IMiddleware = async (
     const res = await resolve(parent, args, ctx, info)
     return res
   } catch (e) {
-    logger.error('Got error in resolver')
     getInnerErrorsFromCombinedError(e).forEach((err) =>
       sentry.captureException(err),
     )


### PR DESCRIPTION
# Jira Issue: []

## What?
- Strip away our tripple logging on errors

## Why?
- If you check datadog, you'll notice that each failure triggers 3 error log statements, where 2 of them are redundant
- https://app.datadoghq.eu/logs?event&index=%2A&query=status%3Aerror+service%3Agiraffe

## Optional checklist
- [ ] Unit tests written
- [ ] Tested locally
- [x] Codescouted
