### PR TITLE
Include more statuses in what is considered 'active'

### DIFF
--- a/src/resolvers/__snapshots__/contracts.test.ts.snap
+++ b/src/resolvers/__snapshots__/contracts.test.ts.snap
@@ -1,5 +1,78 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Query.activeContractBundles Include ACTIVE and ACTIVE-ish contracts 1`] = `
+Array [
+  Object {
+    "angelStories": Object {
+      "addressChange": null,
+    },
+    "contracts": Array [
+      Object {
+        "createdAt": "2020-12-01T10:00:00Z",
+        "currentAgreement": Object {
+          "__typename": "DanishHomeContentAgreement",
+          "activeFrom": "2020-12-01",
+          "activeTo": null,
+          "address": Object {
+            "postalCode": "12345",
+            "street": "Fakestreet 123",
+          },
+          "certificateUrl": null,
+          "id": "aid1",
+          "numberCoInsured": 2,
+          "premium": Object {
+            "amount": "120",
+            "currency": "SEK",
+          },
+          "status": "ACTIVE",
+        },
+        "displayName": "CONTRACT_DISPLAY_NAME_DK_HOME_CONTENT_OWN",
+        "holderMember": "mid",
+        "id": "cid1",
+        "inception": "2021-03-01",
+        "status": Object {
+          "__typename": "ActiveStatus",
+          "pastInception": "2021-03-01",
+        },
+        "switchedFromInsuranceProvider": "IF",
+        "typeOfContract": "DK_HOME_CONTENT_OWN",
+      },
+      Object {
+        "createdAt": "2020-12-01T10:00:00Z",
+        "currentAgreement": Object {
+          "__typename": "DanishAccidentAgreement",
+          "activeFrom": "2020-12-01",
+          "activeTo": null,
+          "address": Object {
+            "postalCode": "12345",
+            "street": "Fakestreet 123",
+          },
+          "certificateUrl": null,
+          "id": "aid1",
+          "numberCoInsured": 2,
+          "premium": Object {
+            "amount": "120",
+            "currency": "SEK",
+          },
+          "status": "ACTIVE",
+        },
+        "displayName": "CONTRACT_DISPLAY_NAME_DK_ACCIDENT",
+        "holderMember": "mid",
+        "id": "cid2",
+        "inception": "2021-03-01",
+        "status": Object {
+          "__typename": "TerminatedInFutureStatus",
+          "futureTermination": null,
+        },
+        "switchedFromInsuranceProvider": "IF",
+        "typeOfContract": "DK_ACCIDENT",
+      },
+    ],
+    "id": "bundle-cid1,cid2",
+  },
+]
+`;
+
 exports[`Query.activeContractBundles becomes a single bundle for danish contracts 1`] = `
 Array [
   Object {
@@ -252,50 +325,6 @@ Array [
       },
     ],
     "id": "bundle-cid2",
-  },
-]
-`;
-
-exports[`Query.activeContractBundles non-active contracts are ignored 1`] = `
-Array [
-  Object {
-    "angelStories": Object {
-      "addressChange": null,
-    },
-    "contracts": Array [
-      Object {
-        "createdAt": "2020-12-01T10:00:00Z",
-        "currentAgreement": Object {
-          "__typename": "NorwegianHomeContentAgreement",
-          "activeFrom": "2020-12-01",
-          "activeTo": null,
-          "address": Object {
-            "postalCode": "12345",
-            "street": "Fakestreet 123",
-          },
-          "certificateUrl": null,
-          "id": "aid1",
-          "numberCoInsured": 2,
-          "premium": Object {
-            "amount": "120",
-            "currency": "SEK",
-          },
-          "squareMeters": 77,
-          "status": "ACTIVE",
-        },
-        "displayName": "CONTRACT_DISPLAY_NAME_NO_HOME_CONTENT_OWN",
-        "holderMember": "mid",
-        "id": "cid1",
-        "inception": "2021-03-01",
-        "status": Object {
-          "__typename": "ActiveStatus",
-          "pastInception": "2021-03-01",
-        },
-        "switchedFromInsuranceProvider": "IF",
-        "typeOfContract": "NO_HOME_CONTENT_OWN",
-      },
-    ],
-    "id": "bundle-cid1",
   },
 ]
 `;

--- a/src/resolvers/contracts.test.ts
+++ b/src/resolvers/contracts.test.ts
@@ -80,19 +80,24 @@ describe('Query.activeContractBundles', () => {
     expect(result).toMatchSnapshot()
   })
 
-  it('non-active contracts are ignored', async () => {
+  it('Include ACTIVE and ACTIVE-ish contracts', async () => {
     const homeContent = {
-      ...norwegianHomeContentInput,
+      ...danishHomeContentInput,
       id: 'cid1',
       status: ContractStatusDto.ACTIVE
     }
-    const travel = {
-      ...norwegianTravelInput,
+    const accident = {
+      ...danishAccidentInput,
       id: 'cid2',
+      status: ContractStatusDto.TERMINATED_IN_FUTURE
+    }
+    const travel = {
+      ...danishTravelInput,
+      id: 'cid3',
       status: ContractStatusDto.TERMINATED
     }
     apollo.upstream.productPricing.getMemberContracts = () =>
-      Promise.resolve([homeContent, travel])
+      Promise.resolve([homeContent, accident, travel])
 
     const result = await CALLS.activeContractBundles()
 

--- a/src/resolvers/contracts.ts
+++ b/src/resolvers/contracts.ts
@@ -49,8 +49,13 @@ export const activeContractBundles: QueryResolvers['activeContractBundles'] = as
     addressChangeAngelStoryId = ADDRESS_CHANGE_STORIES_BY_MARKET[marketInfo.market.toUpperCase()]
   }
 
-  const active = contracts.filter(c => c.status == ContractStatusDto.ACTIVE)
-  return bundleContracts(strings, active, addressChangeAngelStoryId)
+  const activeishStatuses = [
+    ContractStatusDto.ACTIVE,
+    ContractStatusDto.TERMINATED_IN_FUTURE,
+    ContractStatusDto.TERMINATED_TODAY
+  ]
+  const activeish = contracts.filter(c => activeishStatuses.includes(c.status))
+  return bundleContracts(strings, activeish, addressChangeAngelStoryId)
 }
 
 export const contracts: QueryResolvers['contracts'] = async (


### PR DESCRIPTION
# Jira Issue: []

## What?
- Widen what we consider to be an 'active' contract

## Why?
- The `ContractStatus`es have a bit of overlap. A contract is "active" if it is active right now but terminated in the future, however then it won't have the `ACTIVE` status, but rather a `TERMINATED_IN_FUTURE` one.
- https://hedviginsurance.slack.com/archives/C01NB6GBRFS/p1626162624003900

## Optional checklist
- [x] Unit tests written
- [ ] Tested locally
- [x] Codescouted
