### PR TITLE
APP-637: Address Change - allow no extra buildings when submitting for `SE_HOUSE`

### DIFF
--- a/src/resolvers/__snapshots__/addressChange.test.ts.snap
+++ b/src/resolvers/__snapshots__/addressChange.test.ts.snap
@@ -189,6 +189,33 @@ Array [
 ]
 `;
 
+exports[`createAddressChangeQuotes - SE_HOUSE accepts undefined for \`extraBuildings\` 1`] = `
+Array [
+  Array [
+    Object {
+      "birthDate": "1991-07-27",
+      "firstName": "Test",
+      "initiatedFrom": "SELF_CHANGE",
+      "lastName": "Testsson",
+      "memberId": "123",
+      "ssn": "201212121212",
+      "startDate": "2021-06-01",
+      "swedishHouseData": Object {
+        "ancillaryArea": 28,
+        "extraBuildings": Array [],
+        "householdSize": 3,
+        "livingSpace": 44,
+        "numberOfBathrooms": 3,
+        "street": "Fakestreet 123",
+        "subleted": true,
+        "yearOfConstruction": 1912,
+        "zipCode": "12345",
+      },
+    },
+  ],
+]
+`;
+
 exports[`createAddressChangeQuotes - SE_HOUSE works 1`] = `
 Array [
   Array [

--- a/src/resolvers/addressChange.test.ts
+++ b/src/resolvers/addressChange.test.ts
@@ -1,7 +1,9 @@
-import { ContractStatusDto } from '../api/upstreams/productPricing'
 import gql from 'graphql-tag'
-import { ContractMarketInfoDto } from '../api/upstreams/productPricing'
 import { MemberDto } from '../api/upstreams/memberService'
+import {
+  ContractMarketInfoDto,
+  ContractStatusDto,
+} from '../api/upstreams/productPricing'
 import { startApolloTesting } from '../test-utils/test-server'
 
 const { mutate, upstream } = startApolloTesting()
@@ -81,7 +83,7 @@ describe('createAddressChangeQuotes - Denmark', () => {
 
 const MUTATIONS = {
   createAddressChangeQuotes: async (input: any) =>
-    await mutate({
+    mutate({
       mutation: gql`
         mutation($input: AddressChangeInput!) {
           createAddressChangeQuotes(input: $input) {
@@ -99,12 +101,13 @@ const MUTATIONS = {
 }
 
 const mockMarket = (market: string) => {
-  upstream.productPricing.getContractMarketInfo = () => Promise.resolve({
-    ...marketInfo,
-    market,
-  })
+  upstream.productPricing.getContractMarketInfo = () =>
+    Promise.resolve({
+      ...marketInfo,
+      market,
+    })
 }
-  
+
 const mockContracts = (typesOfContract: string[]) => {
   const mock = jest.fn()
   typesOfContract.forEach((typeOfContract, index) =>
@@ -112,7 +115,7 @@ const mockContracts = (typesOfContract: string[]) => {
       id: `cid${index}`,
       status: ContractStatusDto.ACTIVE,
       typeOfContract,
-    })
+    }),
   )
   upstream.productPricing.getContract = mock
 }

--- a/src/resolvers/addressChange.test.ts
+++ b/src/resolvers/addressChange.test.ts
@@ -53,6 +53,11 @@ describe('createAddressChangeQuotes - SE_HOUSE', () => {
     await MUTATIONS.createAddressChangeQuotes(seHouse)
     expect(createQuote.mock.calls).toMatchSnapshot()
   })
+
+  it('accepts undefined for `extraBuildings`', async () => {
+    await MUTATIONS.createAddressChangeQuotes(seHouseNoExtraBuildings)
+    expect(createQuote.mock.calls).toMatchSnapshot()
+  })
 })
 
 describe('createAddressChangeQuotes - Norway', () => {
@@ -186,6 +191,17 @@ const seHouse = {
       hasWaterConnected: false,
     },
   ],
+  ownership: 'OWN',
+  isStudent: false,
+}
+
+const seHouseNoExtraBuildings = {
+  ...baseInput,
+  type: 'HOUSE',
+  ancillaryArea: 28,
+  yearOfConstruction: 1912,
+  numberOfBathrooms: 3,
+  isSubleted: true,
   ownership: 'OWN',
   isStudent: false,
 }

--- a/src/resolvers/addressChange.ts
+++ b/src/resolvers/addressChange.ts
@@ -118,7 +118,7 @@ const toSwedishQuoteDto = (
           yearOfConstruction: input.yearOfConstruction!,
           numberOfBathrooms: input.numberOfBathrooms!,
           subleted: input.isSubleted!,
-          extraBuildings: input.extraBuildings!,
+          extraBuildings: input.extraBuildings ?? [],
         },
       }
   }

--- a/src/resolvers/addressChange.ts
+++ b/src/resolvers/addressChange.ts
@@ -103,7 +103,7 @@ const toSwedishQuoteDto = (
           zipCode: input.zip,
           householdSize: input.numberCoInsured + 1,
           livingSpace: input.livingSpace,
-          subType: subtypeMapper(input.ownership, input.isStudent!!),
+          subType: subtypeMapper(input.ownership, input.isStudent!),
         },
       }
     case AddressHomeType.House:
@@ -114,11 +114,11 @@ const toSwedishQuoteDto = (
           zipCode: input.zip,
           householdSize: input.numberCoInsured + 1,
           livingSpace: input.livingSpace,
-          ancillaryArea: input.ancillaryArea!!,
-          yearOfConstruction: input.yearOfConstruction!!,
-          numberOfBathrooms: input.numberOfBathrooms!!,
-          subleted: input.isSubleted!!,
-          extraBuildings: input.extraBuildings!!,
+          ancillaryArea: input.ancillaryArea!,
+          yearOfConstruction: input.yearOfConstruction!,
+          numberOfBathrooms: input.numberOfBathrooms!,
+          subleted: input.isSubleted!,
+          extraBuildings: input.extraBuildings!,
         },
       }
   }

--- a/src/schema.graphqls
+++ b/src/schema.graphqls
@@ -399,7 +399,7 @@ input AddressChangeInput {
   numberOfBathrooms: Int
   """Is this property subleted? Required if type == HOUSE."""
   isSubleted: Boolean
-  """A list of extra buildings outside of the main property. Required if type == HOUSE."""
+  """A list of extra buildings outside of the main property."""
   extraBuildings: [AddressHouseExtraBuilding!]
 }
 


### PR DESCRIPTION
- Reformat file using prettier
- Replace `!!` with `!`
- Reformat file using prettier
- Allow undefined as input for `extraBuildings`

# Jira Issue: [APP-637]

## What?
Allow `extraBuildings` to not be submitted when creating address change quotes for
`SE_HOUSE`. If no `extraBuildings` are provided, default it to `[]` in the
upstream API.

## Why?
Some Embark-based clients (specifically android in this case) did not set any
value when no MultiAction-items were provided, leading to this mutation being
called with `extraBuildings: undefined` instead of `extraBuildings: []`. An
alternative implementation path could have been to set `extraBuildings: []`, but
we determined it to be sensible to change this mutation to instead work in this
manner.

## Optional checklist
- [X] Unit tests written
- [ ] Tested locally
- [X] Codescouted


[APP-637]: https://hedvig.atlassian.net/browse/APP-637